### PR TITLE
Wiki website moving

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+rbap.bobdevstudio.org

--- a/Wiki/Dock-Entrance-Type-Pages/Game/Donations-Dock.md
+++ b/Wiki/Dock-Entrance-Type-Pages/Game/Donations-Dock.md
@@ -18,7 +18,7 @@ page_subject_info:
         - key: "Sign Text"
           value: "`[Donations Dock]: This dock houses the game's donation system`"
         - key: "Is System Dock"
-          value: "`True` - [Donations Dock](/RBAP-Wiki/Wiki/Docks/Donations-Dock)"
+          value: "`True` - [Donations Dock](/Wiki/Docks/Donations-Dock)"
         - key: "Is Bridge Down"
           value: "`True`"
         - key: "Is Gate Down"
@@ -68,7 +68,7 @@ page_subject_info:
 | Value Name               | Value |
 |-|-|
 | Sign Text                | `[Donations Dock]: This dock houses the game's donation system` |
-| Is System Dock           | `True` - [Donations Dock](/RBAP-Wiki/Wiki/Docks/Donations-Dock) |
+| Is System Dock           | `True` - [Donations Dock](/Wiki/Docks/Donations-Dock) |
 | Is Bridge Down           | `True` |
 | Is Gate Down             | `True` |
 | Main Light 1 On          | `True` |

--- a/Wiki/Dock-Entrance-Type-Pages/Game/Game-Info-Dock.md
+++ b/Wiki/Dock-Entrance-Type-Pages/Game/Game-Info-Dock.md
@@ -18,7 +18,7 @@ page_subject_info:
         - key: "Sign Text"
           value: "`[Game Info Dock]: This dock contains signs that give all sorts of info about the game`"
         - key: "Is System Dock"
-          value: "`True` - [Game Info Dock](/RBAP-Wiki/Wiki/Docks/Game-Info-Dock)"
+          value: "`True` - [Game Info Dock](/Wiki/Docks/Game-Info-Dock)"
         - key: "Is Bridge Down"
           value: "`True`"
         - key: "Is Gate Down"
@@ -68,7 +68,7 @@ page_subject_info:
 | Value Name               | Value |
 |-|-|
 | Sign Text                | `[Game Info Dock]: This dock contains signs that give all sorts of info about the game` |
-| Is System Dock           | `True` - [Game Info Dock](/RBAP-Wiki/Wiki/Docks/Game-Info-Dock) |
+| Is System Dock           | `True` - [Game Info Dock](/Wiki/Docks/Game-Info-Dock) |
 | Is Bridge Down           | `True` |
 | Is Gate Down             | `True` |
 | Main Light 1 On          | `True` |

--- a/Wiki/Dock-Entrance-Type-Pages/Game/Main-Build-Purchases-Closed.md
+++ b/Wiki/Dock-Entrance-Type-Pages/Game/Main-Build-Purchases-Closed.md
@@ -61,7 +61,7 @@ page_subject_info:
 
 This dock entrance type's purpose is to close off a dock that has purchases. The reason for this is because many of the things you can purchase in game (or actually all of them at the time of writing) are uploaded to the main build of the game instead of other special builds of the game like pre-update build. Roblox *theoretically* (or at least logically) allows purchases to be made if the asset behind the purchase is owned by the same thing as the game but in reality BOB has found this functionality to be broken or nonexistent.
 
-This dock entrance type can never be found inside of the main build but can be found in other special builds of the game (with the exception of the dev build (for debugging purposes)). It is currently only being applied to the [Donations Dock](/RBAP-Wiki/Wiki/Docks/Donations-Dock) for the reasons listed above.
+This dock entrance type can never be found inside of the main build but can be found in other special builds of the game (with the exception of the dev build (for debugging purposes)). It is currently only being applied to the [Donations Dock](/Wiki/Docks/Donations-Dock) for the reasons listed above.
 
 | Value Name               | Value |
 |-|-|

--- a/Wiki/Dock-Entrance-Type-Pages/Game/NPCs-Key-Dock.md
+++ b/Wiki/Dock-Entrance-Type-Pages/Game/NPCs-Key-Dock.md
@@ -18,7 +18,7 @@ page_subject_info:
         - key: "Sign Text"
           value: "`[NPCs Key Dock]: This dock contains info about each of the NPCs that can be seen in the game`"
         - key: "Is System Dock"
-          value: "`True` - [NPCs Key Dock](/RBAP-Wiki/Wiki/Docks/NPCs-Key-Dock)"
+          value: "`True` - [NPCs Key Dock](/Wiki/Docks/NPCs-Key-Dock)"
         - key: "Is Bridge Down"
           value: "`True`"
         - key: "Is Gate Down"
@@ -63,12 +63,12 @@ page_subject_info:
           value: "*Default (unset)*"
 ---
 
-This dock entrance type is indirectly inspired by the [NPCs Key Dock](/RBAP-Wiki/Wiki/Docks/NPCs-Key-Dock)'s original system dock entrance type.
+This dock entrance type is indirectly inspired by the [NPCs Key Dock](/Wiki/Docks/NPCs-Key-Dock)'s original system dock entrance type.
 
 | Value Name               | Value |
 |-|-|
 | Sign Text                | `[NPCs Key Dock]: This dock contains info about each of the NPCs that can be seen in the game` |
-| Is System Dock           | `True` - [NPCs Key Dock](/RBAP-Wiki/Wiki/Docks/NPCs-Key-Dock) |
+| Is System Dock           | `True` - [NPCs Key Dock](/Wiki/Docks/NPCs-Key-Dock) |
 | Is Bridge Down           | `True` |
 | Is Gate Down             | `True` |
 | Main Light 1 On          | `False` |

--- a/Wiki/Dock-Entrance-Type-Pages/Removed/Cooldown.md
+++ b/Wiki/Dock-Entrance-Type-Pages/Removed/Cooldown.md
@@ -59,7 +59,7 @@ page_subject_info:
           value: "*Default (unset)*"
 ---
 
-This dock entrance type was originally added for the [Mine Dock](/RBAP-Wiki/Wiki/Docks/Mine-Dock) but the idea of using it there was later scrapped before the update that it was in came out. So this dock entrance type was never actually used. It still has a possibility of being used but is unlikely.
+This dock entrance type was originally added for the [Mine Dock](/Wiki/Docks/Mine-Dock) but the idea of using it there was later scrapped before the update that it was in came out. So this dock entrance type was never actually used. It still has a possibility of being used but is unlikely.
 
 | Value Name               | Value |
 |-|-|

--- a/Wiki/Dock-Entrance-Type-Pages/Removed/Hidden-Dock.md
+++ b/Wiki/Dock-Entrance-Type-Pages/Removed/Hidden-Dock.md
@@ -59,7 +59,7 @@ page_subject_info:
           value: "*Default (unset)*"
 ---
 
-Hidden docks are docks that are hidden by default unless they are triggered to appear by some in-game event. There are currently none in the game that use this dock entrance type as previous ones were removed in [`V3`](/RBAP-Wiki/Posts/Update-Log/3-0-0) of the game due to limitations of newly-implemented systems (like the dock placing system). Some of the limitations still have yet to be lifted as of [`V4`](/RBAP-Wiki/Posts/Update-Log/4-0-0) the most notable being the dock placing system.
+Hidden docks are docks that are hidden by default unless they are triggered to appear by some in-game event. There are currently none in the game that use this dock entrance type as previous ones were removed in [`V3`](/Posts/Update-Log/3-0-0) of the game due to limitations of newly-implemented systems (like the dock placing system). Some of the limitations still have yet to be lifted as of [`V4`](/Posts/Update-Log/4-0-0) the most notable being the dock placing system.
 
 | Value Name               | Value |
 |-|-|

--- a/Wiki/Dock-Entrance-Type-Pages/Removed/Server-Dock.md
+++ b/Wiki/Dock-Entrance-Type-Pages/Removed/Server-Dock.md
@@ -18,7 +18,7 @@ page_subject_info:
         - key: "Sign Text"
           value: "`[Server Dock]: This dock contains statistics about the server and the game`"
         - key: "Is System Dock"
-          value: "`True` - [Server And Game Info Dock](/RBAP-Wiki/Wiki/Docks/Category/In-Game#server-and-game-info-dock)"
+          value: "`True` - [Server And Game Info Dock](/Wiki/Docks/Category/In-Game#server-and-game-info-dock)"
         - key: "Is Bridge Down"
           value: "`True`"
         - key: "Is Gate Down"
@@ -68,7 +68,7 @@ page_subject_info:
 | Value Name               | Value |
 |-|-|
 | Sign Text                | `[Server Dock]: This dock contains statistics about the server and the game` |
-| Is System Dock           | `True` - [Server And Game Info Dock](/RBAP-Wiki/Wiki/Docks/Category/In-Game#server-and-game-info-dock) |
+| Is System Dock           | `True` - [Server And Game Info Dock](/Wiki/Docks/Category/In-Game#server-and-game-info-dock) |
 | Is Bridge Down           | `True` |
 | Is Gate Down             | `True` |
 | Main Light 1 On          | `True` |

--- a/Wiki/Dock-Entrance-Type-Pages/Removed/Update-Logs-Dock.md
+++ b/Wiki/Dock-Entrance-Type-Pages/Removed/Update-Logs-Dock.md
@@ -18,7 +18,7 @@ page_subject_info:
         - key: "Sign Text"
           value: "`[Update Logs Dock]: This dock contains Random Buildings And Parts update logs`"
         - key: "Is System Dock"
-          value: "`True` - [Update Logs Dock](/RBAP-Wiki/Wiki/Docks/Category/In-Game#update-logs-dock)"
+          value: "`True` - [Update Logs Dock](/Wiki/Docks/Category/In-Game#update-logs-dock)"
         - key: "Is Bridge Down"
           value: "`True`"
         - key: "Is Gate Down"
@@ -68,7 +68,7 @@ page_subject_info:
 | Value Name               | Value |
 |-|-|
 | Sign Text                | `[Update Logs Dock]: This dock contains Random Buildings And Parts update logs` |
-| Is System Dock           | `True` - [Update Logs Dock](/RBAP-Wiki/Wiki/Docks/Category/In-Game#update-logs-dock) |
+| Is System Dock           | `True` - [Update Logs Dock](/Wiki/Docks/Category/In-Game#update-logs-dock) |
 | Is Bridge Down           | `True` |
 | Is Gate Down             | `True` |
 | Main Light 1 On          | `True` |

--- a/Wiki/Dock-Entrance-Types.md
+++ b/Wiki/Dock-Entrance-Types.md
@@ -7,7 +7,7 @@ listed_page_category: "dockentrancetypes_category_page"
 
 What is a dock entrance type? A dock entrance type is the status of the dock entrance that a dock is connected to. Usually it isn't something that describes the dock unless it is something like a system dock. Dock types can set many appearance settings of the dock entrance for a dock. The list includes stuff like light colors, lights that are on, the text shown on the sign, and more. Currently the text of the sign on each dock entrance is automatically made entirely uppercase.
 
-What is a system dock? System docks are currently being classified as docks that are not a thing for showcase purposes but rather for informational purposes or something else integrated with the game itself (an example of that is the [server system dock](/RBAP-Wiki/Wiki/Docks/Category/In-Game#server-and-game-info-dock)). Each system dock gets its own custom dock entrance type which the text of the sign is automatically prefixed with `[System Dock]:`.
+What is a system dock? System docks are currently being classified as docks that are not a thing for showcase purposes but rather for informational purposes or something else integrated with the game itself (an example of that is the [server system dock](/Wiki/Docks/Category/In-Game#server-and-game-info-dock)). Each system dock gets its own custom dock entrance type which the text of the sign is automatically prefixed with `[System Dock]:`.
 
 ## Dock Entrance Type Data Default Values:
 

--- a/Wiki/Dock-Pages/Game/Bloxy-Statue-Remade-Dock.md
+++ b/Wiki/Dock-Pages/Game/Bloxy-Statue-Remade-Dock.md
@@ -16,7 +16,7 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Main Side 1`"
 ---
@@ -27,7 +27,7 @@ This is BOB's re-creation of Roblox Bloxy Statue. It was made sometime after the
 |-|-|
 | Reserved Dock Entrance   | *None (unset)* |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)} |
+| Dock Entrance Types Used | {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)} |
 | Side Placed On           | `Main Side 1` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Game/Bob-The-Mob-Dock.md
+++ b/Wiki/Dock-Pages/Game/Bob-The-Mob-Dock.md
@@ -16,7 +16,7 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Main Side 1`"
 ---
@@ -27,7 +27,7 @@ BOB was inspired to make this dock after a reply to a post that BOB made on Twit
 |-|-|
 | Reserved Dock Entrance   | *None (unset)* |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)} |
+| Dock Entrance Types Used | {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)} |
 | Side Placed On           | `Main Side 1` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Game/Camp-Fire-Dock.md
+++ b/Wiki/Dock-Pages/Game/Camp-Fire-Dock.md
@@ -16,7 +16,7 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Main Side 1`"
 ---
@@ -27,7 +27,7 @@ page_subject_info:
 |-|-|
 | Reserved Dock Entrance   | *None (unset)* |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)} |
+| Dock Entrance Types Used | {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)} |
 | Side Placed On           | `Main Side 1` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Game/Construction-Barrier-Dock.md
+++ b/Wiki/Dock-Pages/Game/Construction-Barrier-Dock.md
@@ -16,7 +16,7 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Main Side 1`"
 ---
@@ -29,7 +29,7 @@ The project that this is referring to has yet to make it very far in terms of pr
 |-|-|
 | Reserved Dock Entrance   | *None (unset)* |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)} |
+| Dock Entrance Types Used | {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)} |
 | Side Placed On           | `Main Side 1` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Game/Donations-Dock.md
+++ b/Wiki/Dock-Pages/Game/Donations-Dock.md
@@ -16,12 +16,12 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Donations Dock`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Donations-Dock)} or {`1` = [`Main Build Purchases Closed`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Main-Build-Purchases-Closed)}"
+          value: "{`1` = [`Donations Dock`](/Wiki/Dock-Entrance-Types/Donations-Dock)} or {`1` = [`Main Build Purchases Closed`](/Wiki/Dock-Entrance-Types/Main-Build-Purchases-Closed)}"
         - key: "Side Placed On"
           value: "`Main Side 2`"
 ---
 
-After a lot of the screen UI in the game was removed this dock was added to replace the old donation screen UI. As a thank you for purchasing a donation an update before [`V4`](/RBAP-Wiki/Posts/Update-Log/4-0-0) added a little celebration animation after a player purchases any of the donation amounts available. [`V4.1`](/RBAP-Wiki/Posts/Update-Log/4-1-0) added another way to thank you for your donation which is when you purchase any of the donation amounts available you will get that donation amount's corresponding title. This dock has not always been considered a system dock.
+After a lot of the screen UI in the game was removed this dock was added to replace the old donation screen UI. As a thank you for purchasing a donation an update before [`V4`](/Posts/Update-Log/4-0-0) added a little celebration animation after a player purchases any of the donation amounts available. [`V4.1`](/Posts/Update-Log/4-1-0) added another way to thank you for your donation which is when you purchase any of the donation amounts available you will get that donation amount's corresponding title. This dock has not always been considered a system dock.
 
 The prices of each of the donation amounts available is meant to be able to help the user donate the exact (or close to the) amount of Robux that they want to donate.
 
@@ -40,7 +40,7 @@ The prices of each of the donation amounts available is meant to be able to help
 |-|-|
 | Reserved Dock Entrance   | `2` |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Donations Dock`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Donations-Dock)} or {`1` = [`Main Build Purchases Closed`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Main-Build-Purchases-Closed)} |
+| Dock Entrance Types Used | {`1` = [`Donations Dock`](/Wiki/Dock-Entrance-Types/Donations-Dock)} or {`1` = [`Main Build Purchases Closed`](/Wiki/Dock-Entrance-Types/Main-Build-Purchases-Closed)} |
 | Side Placed On           | `Main Side 2` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Game/Game-Info-Dock.md
+++ b/Wiki/Dock-Pages/Game/Game-Info-Dock.md
@@ -16,18 +16,18 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Game Info Dock`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Game-Info-Dock)}"
+          value: "{`1` = [`Game Info Dock`](/Wiki/Dock-Entrance-Types/Game-Info-Dock)}"
         - key: "Side Placed On"
           value: "`Main Side 1`"
 ---
 
-The Game Info Dock is a dock added in [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0). Its purpose is to hold signs that display all sorts of information about the game; rather than giving each sign its own dock which is not space efficient at all. Although (unlike the Credits Sign) there is no direct proof of it, the Idea for the dock has been around longer than [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) but the extent of that is unknown. This dock is just meant to help save space and put everything in a centralized place instead of everything being spread out all over the map in their own docks. This dock has always been considered a system dock (for what should be obvious reasons). This dock was the first dock to use BOB's new sign design although as of [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) BOB has yet to decide whether all signs will be changed to it or not.
+The Game Info Dock is a dock added in [`V5`](/Posts/Update-Log/5-0-0). Its purpose is to hold signs that display all sorts of information about the game; rather than giving each sign its own dock which is not space efficient at all. Although (unlike the Credits Sign) there is no direct proof of it, the Idea for the dock has been around longer than [`V5`](/Posts/Update-Log/5-0-0) but the extent of that is unknown. This dock is just meant to help save space and put everything in a centralized place instead of everything being spread out all over the map in their own docks. This dock has always been considered a system dock (for what should be obvious reasons). This dock was the first dock to use BOB's new sign design although as of [`V5`](/Posts/Update-Log/5-0-0) BOB has yet to decide whether all signs will be changed to it or not.
 
 | Value Name               | Value |
 |-|-|
 | Reserved Dock Entrance   | `1` |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Game Info Dock`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Game-Info-Dock)} |
+| Dock Entrance Types Used | {`1` = [`Game Info Dock`](/Wiki/Dock-Entrance-Types/Game-Info-Dock)} |
 | Side Placed On           | `Main Side 1` |
 {: .psi-panel-alternative}
 
@@ -37,12 +37,12 @@ The Game Info Dock is a dock added in [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0).
 
 ### Server And Game Info Sign
 
-This sign was originally pulled from the old [Server And Game Info Dock](/RBAP-Wiki/Wiki/Docks/Server-And-Game-Info-Dock) at the time that this dock was created. Besides going through a visual redesign when the dock was being created, as of [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) nothing else has changed.
+This sign was originally pulled from the old [Server And Game Info Dock](/Wiki/Docks/Server-And-Game-Info-Dock) at the time that this dock was created. Besides going through a visual redesign when the dock was being created, as of [`V5`](/Posts/Update-Log/5-0-0) nothing else has changed.
 
 ### Update Logs Sign
 
-This sign was originally pulled from the old [Update Logs Dock](/RBAP-Wiki/Wiki/Docks/Update-Logs-Dock) at the time that this dock was created. Besides going through a visual redesign when the dock was being created, as of [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) nothing else has changed.
+This sign was originally pulled from the old [Update Logs Dock](/Wiki/Docks/Update-Logs-Dock) at the time that this dock was created. Besides going through a visual redesign when the dock was being created, as of [`V5`](/Posts/Update-Log/5-0-0) nothing else has changed.
 
 ### Credits Sign
 
-This sign displays the game's credits and is not pulled from a previously existing dock. This sign was added along with the dock however the idea for this sign dates back to before [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) even entered production.
+This sign displays the game's credits and is not pulled from a previously existing dock. This sign was added along with the dock however the idea for this sign dates back to before [`V5`](/Posts/Update-Log/5-0-0) even entered production.

--- a/Wiki/Dock-Pages/Game/Game-Rooms-Dock.md
+++ b/Wiki/Dock-Pages/Game/Game-Rooms-Dock.md
@@ -16,7 +16,7 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Middle Side 2`"
 ---
@@ -27,7 +27,7 @@ page_subject_info:
 |-|-|
 | Reserved Dock Entrance   | `1` |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)} |
+| Dock Entrance Types Used | {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)} |
 | Side Placed On           | `Middle Side 2` |
 {: .psi-panel-alternative}
 
@@ -35,24 +35,24 @@ page_subject_info:
 
 ## Four Corners
 
-Four Corners is a classic game where there are four corners and only one of them will (in this case) be sunk. The four colors to choose from are red, green, blue, and Unbitterness' favorite color. This game used to only have 1 round due to how the dock was originally envisioned but in [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) it was increased to 5. This game was made to be a remake of the Four Corners game of the [Old Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Old-Game-Rooms-Dock).
+Four Corners is a classic game where there are four corners and only one of them will (in this case) be sunk. The four colors to choose from are red, green, blue, and Unbitterness' favorite color. This game used to only have 1 round due to how the dock was originally envisioned but in [`V5`](/Posts/Update-Log/5-0-0) it was increased to 5. This game was made to be a remake of the Four Corners game of the [Old Game Rooms Dock](/Wiki/Docks/Old-Game-Rooms-Dock).
 
 <img class="dock-image" src="/RBAP-Wiki/Assets/Images/Docks/Game-Rooms-Games/Four-Corners.png" alt="">
 
 ## Four Corners: Reversed
 
-This is basically the exact same game as the Four Corners game but of course only one color is safe instead of three being safe. Like the normal Four Corners, this game was made to be a remake of the Four Corners: Reversed game of the [Old Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Old-Game-Rooms-Dock).
+This is basically the exact same game as the Four Corners game but of course only one color is safe instead of three being safe. Like the normal Four Corners, this game was made to be a remake of the Four Corners: Reversed game of the [Old Game Rooms Dock](/Wiki/Docks/Old-Game-Rooms-Dock).
 
 <img class="dock-image" src="/RBAP-Wiki/Assets/Images/Docks/Game-Rooms-Games/Four-Corners-Reversed.png" alt="">
 
 ## Game Says
 
-This game is basically the equivalent to a commonly played game called Simon Says. How this game works is the main sign will give some instruction along with who said the instruction and if the game is one who said it you should do it it says but if it isn't you should do the opposite of what it says. It purposely does not give you much time to think about the instructions before the barriers are enabled and platforms start sinking. This game used to have 10 rounds but was lowered down to 5 rounds in [`V4.1`](/RBAP-Wiki/Posts/Update-Log/4-1-0) and then up to 7 in [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0). Unlike the Four Corners games this one is **not** a remake of a previous game from the old game rooms dock. Rather it is a replacement for the game from the [Old Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Old-Game-Rooms-Dock) called Find The Right Color and (for the time being at least) the harder variant of it called Find The Right Color: Harder And Harder.
+This game is basically the equivalent to a commonly played game called Simon Says. How this game works is the main sign will give some instruction along with who said the instruction and if the game is one who said it you should do it it says but if it isn't you should do the opposite of what it says. It purposely does not give you much time to think about the instructions before the barriers are enabled and platforms start sinking. This game used to have 10 rounds but was lowered down to 5 rounds in [`V4.1`](/Posts/Update-Log/4-1-0) and then up to 7 in [`V5`](/Posts/Update-Log/5-0-0). Unlike the Four Corners games this one is **not** a remake of a previous game from the old game rooms dock. Rather it is a replacement for the game from the [Old Game Rooms Dock](/Wiki/Docks/Old-Game-Rooms-Dock) called Find The Right Color and (for the time being at least) the harder variant of it called Find The Right Color: Harder And Harder.
 
 <img class="dock-image" src="/RBAP-Wiki/Assets/Images/Docks/Game-Rooms-Games/Game-Says.png" alt="">
 
 ## Light Chaser
 
-This game was added in [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0). How this game works is players must chase around a constantly moving light until it eventually stops. When it stops all platforms that it is not on will be lowered. The point at which it stops is randomly determined every time the light moves.
+This game was added in [`V5`](/Posts/Update-Log/5-0-0). How this game works is players must chase around a constantly moving light until it eventually stops. When it stops all platforms that it is not on will be lowered. The point at which it stops is randomly determined every time the light moves.
 
 <img class="dock-image" src="/RBAP-Wiki/Assets/Images/Docks/Game-Rooms-Games/Light-Chaser.png" alt="">

--- a/Wiki/Dock-Pages/Game/Ice-Cube-Tray-Dock.md
+++ b/Wiki/Dock-Pages/Game/Ice-Cube-Tray-Dock.md
@@ -16,7 +16,7 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Main Side 1`"
 ---
@@ -27,7 +27,7 @@ page_subject_info:
 |-|-|
 | Reserved Dock Entrance   | *None (unset)* |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)} |
+| Dock Entrance Types Used | {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)} |
 | Side Placed On           | `Main Side 1` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Game/Industrial-Light-Dock.md
+++ b/Wiki/Dock-Pages/Game/Industrial-Light-Dock.md
@@ -16,7 +16,7 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Main Side 1`"
 ---
@@ -27,7 +27,7 @@ BOB created this light just for the fun of it. He uses it (or edited versions of
 |-|-|
 | Reserved Dock Entrance   | *None (unset)* |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)} |
+| Dock Entrance Types Used | {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)} |
 | Side Placed On           | `Main Side 1` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Game/Lighthouse-Dock.md
+++ b/Wiki/Dock-Pages/Game/Lighthouse-Dock.md
@@ -16,7 +16,7 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Main Side 1`"
 ---
@@ -27,7 +27,7 @@ BOB originally created this dock when he was trying to make cylinders out of mul
 |-|-|
 | Reserved Dock Entrance   | *None (unset)* |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)} |
+| Dock Entrance Types Used | {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)} |
 | Side Placed On           | `Main Side 1` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Game/Mine-Dock.md
+++ b/Wiki/Dock-Pages/Game/Mine-Dock.md
@@ -16,7 +16,7 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Main Side 2`"
 ---
@@ -27,7 +27,7 @@ This dock was created just for the fun of it and partly because it was because B
 |-|-|
 | Reserved Dock Entrance   | *None (unset)* |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)} |
+| Dock Entrance Types Used | {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)} |
 | Side Placed On           | `Main Side 2` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Game/Moving-Spotlight-Dock.md
+++ b/Wiki/Dock-Pages/Game/Moving-Spotlight-Dock.md
@@ -16,18 +16,18 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open - New Dock`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open-New-Dock)} but on November 3rd at noon it will automatically be changed to {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open - New Dock`](/Wiki/Dock-Entrance-Types/Open-New-Dock)} but on November 3rd at noon it will automatically be changed to {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Main Side 1` but on November 3rd at noon it will automatically be changed to `Main Side 2`"
 ---
 
-The Moving Spotlight Dock is an interactive dock which contains an edited spotlight model which has the ability to move. When a player is on the dock the spotlight will keep attempting to focus on their character's head. This dock was made sort of as the test to see if BOB could make a spotlight move using only Roblox physics. This dock also holds one of the [Snow Cube](/RBAP-Wiki/Wiki/Snow-Cubes) model's many appearances.
+The Moving Spotlight Dock is an interactive dock which contains an edited spotlight model which has the ability to move. When a player is on the dock the spotlight will keep attempting to focus on their character's head. This dock was made sort of as the test to see if BOB could make a spotlight move using only Roblox physics. This dock also holds one of the [Snow Cube](/Wiki/Snow-Cubes) model's many appearances.
 
 | Value Name               | Value |
 |-|-|
 | Reserved Dock Entrance   | `3` but on November 3rd at noon it will automatically be changed to *None (unset)* |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Open - New Dock`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open-New-Dock)} but on November 3rd at noon it will automatically be changed to {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)} |
+| Dock Entrance Types Used | {`1` = [`Open - New Dock`](/Wiki/Dock-Entrance-Types/Open-New-Dock)} but on November 3rd at noon it will automatically be changed to {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)} |
 | Side Placed On           | `Main Side 1` but on November 3rd at noon it will automatically be changed to `Main Side 2` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Game/NPCs-Key-Dock.md
+++ b/Wiki/Dock-Pages/Game/NPCs-Key-Dock.md
@@ -16,18 +16,18 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`NPCs Key Dock`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/NPCs-Key-Dock)}"
+          value: "{`1` = [`NPCs Key Dock`](/Wiki/Dock-Entrance-Types/NPCs-Key-Dock)}"
         - key: "Side Placed On"
           value: "`Main Side 1`"
 ---
 
-This dock is used to help people figure out what the NPCs in the game represent. This dock was originally considered a system dock but that status was later removed when what defines a system dock was redefined. It was later reconsidered a system dock in [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) due to BOB taking some time to think about what "system dock" should mean in the context of this dock.
+This dock is used to help people figure out what the NPCs in the game represent. This dock was originally considered a system dock but that status was later removed when what defines a system dock was redefined. It was later reconsidered a system dock in [`V5`](/Posts/Update-Log/5-0-0) due to BOB taking some time to think about what "system dock" should mean in the context of this dock.
 
 | Value Name               | Value |
 |-|-|
 | Reserved Dock Entrance   | `15` |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`NPCs Key Dock`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/NPCs-Key-Dock)} |
+| Dock Entrance Types Used | {`1` = [`NPCs Key Dock`](/Wiki/Dock-Entrance-Types/NPCs-Key-Dock)} |
 | Side Placed On           | `Main Side 1` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Game/No-Standing-Joke-Dock.md
+++ b/Wiki/Dock-Pages/Game/No-Standing-Joke-Dock.md
@@ -16,7 +16,7 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Main Side 2`"
 ---
@@ -27,7 +27,7 @@ This was created sometime after BOB was thinking about road signs and then reali
 |-|-|
 | Reserved Dock Entrance   | *None (unset)* |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)} |
+| Dock Entrance Types Used | {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)} |
 | Side Placed On           | `Main Side 2` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Game/Old-Game-Rooms-Dock.md
+++ b/Wiki/Dock-Pages/Game/Old-Game-Rooms-Dock.md
@@ -16,16 +16,16 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`3`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Closed`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Closed), `2` = [`Temporarily Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Temporarily-Open)/[`Temporarily Open - Closing Soon`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Temporarily-Open-Closing-Soon)/[`Temporarily Open - Closed Live`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Temporarily-Open-Closed-Live), `3` = [`Closed`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Closed)}"
+          value: "{`1` = [`Closed`](/Wiki/Dock-Entrance-Types/Closed), `2` = [`Temporarily Open`](/Wiki/Dock-Entrance-Types/Temporarily-Open)/[`Temporarily Open - Closing Soon`](/Wiki/Dock-Entrance-Types/Temporarily-Open-Closing-Soon)/[`Temporarily Open - Closed Live`](/Wiki/Dock-Entrance-Types/Temporarily-Open-Closed-Live), `3` = [`Closed`](/Wiki/Dock-Entrance-Types/Closed)}"
         - key: "Side Placed On"
           value: "`Main Side 2`"
 ---
 
-This is the original game rooms dock. This dock was created to give the player something to do in the game. Although not widely credited for the help, BOB had play testing help from Unbitterness before its release. Before its removal it had remained largely unchanged since it was added. The [replacement for this dock](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock) is in the same location as this dock used to be.
+This is the original game rooms dock. This dock was created to give the player something to do in the game. Although not widely credited for the help, BOB had play testing help from Unbitterness before its release. Before its removal it had remained largely unchanged since it was added. The [replacement for this dock](/Wiki/Docks/Game-Rooms-Dock) is in the same location as this dock used to be.
 
-This dock was removed in a small ceremony added in [`V4`](/RBAP-Wiki/Posts/Update-Log/4-0-0) as (in that same update) the [replacement for the dock](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock) had finally been enabled and made playable. The reason for replacement and then removal is pretty simple: The backend of the dock was/is not really up-to-date with BOB's current way of coding and was/is quite dated and pretty inefficient. Before it was removed BOB made sure that the [replacement dock](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock) had a good replacement for all the features of this dock so no one would feel like major features were lost.
+This dock was removed in a small ceremony added in [`V4`](/Posts/Update-Log/4-0-0) as (in that same update) the [replacement for the dock](/Wiki/Docks/Game-Rooms-Dock) had finally been enabled and made playable. The reason for replacement and then removal is pretty simple: The backend of the dock was/is not really up-to-date with BOB's current way of coding and was/is quite dated and pretty inefficient. Before it was removed BOB made sure that the [replacement dock](/Wiki/Docks/Game-Rooms-Dock) had a good replacement for all the features of this dock so no one would feel like major features were lost.
 
-Although this dock is largely considered removed it can still be seen in the game on the 24th of any month (in the time zone the game uses). This easter egg was added in [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) and the day was chosen by Unbitterness. This easter egg is meant to be a tribute to Unbitterness for helping out with the creation of this dock which was largely uncredited for a while.
+Although this dock is largely considered removed it can still be seen in the game on the 24th of any month (in the time zone the game uses). This easter egg was added in [`V5`](/Posts/Update-Log/5-0-0) and the day was chosen by Unbitterness. This easter egg is meant to be a tribute to Unbitterness for helping out with the creation of this dock which was largely uncredited for a while.
 
 Although she did choose the 24th (on June 24th 2021 (that's where it came from)) she had no idea that it would be used for this. BOB decided not to tell her until a little while after she chose it for the fun of it.
 
@@ -33,7 +33,7 @@ Although she did choose the 24th (on June 24th 2021 (that's where it came from))
 |-|-|
 | Reserved Dock Entrance   | `14` |
 | Entrances Used           | `3` |
-| Dock Entrance Types Used | {`1` = [`Closed`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Closed), `2` = [`Temporarily Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Temporarily-Open)/[`Temporarily Open - Closing Soon`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Temporarily-Open-Closing-Soon)/[`Temporarily Open - Closed Live`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Temporarily-Open-Closed-Live), [`3`](/RBAP-Wiki/Wiki/Value-Types#number) = [`Closed`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Closed)} |
+| Dock Entrance Types Used | {`1` = [`Closed`](/Wiki/Dock-Entrance-Types/Closed), `2` = [`Temporarily Open`](/Wiki/Dock-Entrance-Types/Temporarily-Open)/[`Temporarily Open - Closing Soon`](/Wiki/Dock-Entrance-Types/Temporarily-Open-Closing-Soon)/[`Temporarily Open - Closed Live`](/Wiki/Dock-Entrance-Types/Temporarily-Open-Closed-Live), [`3`](/Wiki/Value-Types#number) = [`Closed`](/Wiki/Dock-Entrance-Types/Closed)} |
 | Side Placed On           | `Main Side 2` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Game/Rainbow-Dance-Floor-Dock.md
+++ b/Wiki/Dock-Pages/Game/Rainbow-Dance-Floor-Dock.md
@@ -16,7 +16,7 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`2`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open), `2` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open), `2` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Main Side 1`"
 ---
@@ -27,7 +27,7 @@ page_subject_info:
 |-|-|
 | Reserved Dock Entrance   | `12` |
 | Entrances Used           | `2` |
-| Dock Entrance Types Used | {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open), `2` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)} |
+| Dock Entrance Types Used | {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open), `2` = [`Open`](/Wiki/Dock-Entrance-Types/Open)} |
 | Side Placed On           | `Main Side 1` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Game/Roblox-Icons-Dock.md
+++ b/Wiki/Dock-Pages/Game/Roblox-Icons-Dock.md
@@ -16,7 +16,7 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Main Side 2`"
 ---
@@ -27,7 +27,7 @@ page_subject_info:
 |-|-|
 | Reserved Dock Entrance   | *None (unset)* |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)} |
+| Dock Entrance Types Used | {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)} |
 | Side Placed On           | `Main Side 2` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Game/Showcase-Dock.md
+++ b/Wiki/Dock-Pages/Game/Showcase-Dock.md
@@ -16,18 +16,18 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Main Side 2`"
 ---
 
-This was created when BOB wanted to make a window with sunlight coming through it like he saw in other showcases (because the lighting system back then was pretty minimalistic compared to how it is now). This **is** the oldest part of the game the second oldest being the [Stage](/RBAP-Wiki/Wiki/Docks/Stage-Dock) (more or less). This was created in the now no longer existent Roblox Legacy lighting technology and that is why it does not look as good as it did when it was made. It is very unlikely that this dock will ever be removed due to its historical value.
+This was created when BOB wanted to make a window with sunlight coming through it like he saw in other showcases (because the lighting system back then was pretty minimalistic compared to how it is now). This **is** the oldest part of the game the second oldest being the [Stage](/Wiki/Docks/Stage-Dock) (more or less). This was created in the now no longer existent Roblox Legacy lighting technology and that is why it does not look as good as it did when it was made. It is very unlikely that this dock will ever be removed due to its historical value.
 
 | Value Name               | Value |
 |-|-|
 | Reserved Dock Entrance   | *None (unset)* |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)} |
+| Dock Entrance Types Used | {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)} |
 | Side Placed On           | `Main Side 2` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Game/Showcase-Remastered-Dock.md
+++ b/Wiki/Dock-Pages/Game/Showcase-Remastered-Dock.md
@@ -16,18 +16,18 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Main Side 2`"
 ---
 
-This is recreation of the [old window showcase](/RBAP-Wiki/Wiki/Docks/Showcase-Dock). This one was made in the late beta of the newest Roblox lighting technology. BOB decided to make this dock just for the fun of it seeing as the old one doesn't look as good as it did when it was made.
+This is recreation of the [old window showcase](/Wiki/Docks/Showcase-Dock). This one was made in the late beta of the newest Roblox lighting technology. BOB decided to make this dock just for the fun of it seeing as the old one doesn't look as good as it did when it was made.
 
 | Value Name               | Value |
 |-|-|
 | Reserved Dock Entrance   | *None (unset)* |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)} |
+| Dock Entrance Types Used | {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)} |
 | Side Placed On           | `Main Side 2` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Game/The-Stage.md
+++ b/Wiki/Dock-Pages/Game/The-Stage.md
@@ -16,14 +16,14 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Middle Side 1`"
 ---
 
 The stage is one of the oldest docks in the game. It is not as old as the original window showcase but it is older than anything besides that still in the game. 
 
-This dock has a history of not actually being in the game. Although nowadays BOB can barely remember the reasons for this, he assumed that the dock was removed temporarily because he probably wanted to remake it at the time (which he did eventually end up doing in [`V3`](/RBAP-Wiki/Posts/Update-Log/3-0-0) of the game). The reason also could have been because of lag or some code of it needing to be updated when BOB didn't feel like it.
+This dock has a history of not actually being in the game. Although nowadays BOB can barely remember the reasons for this, he assumed that the dock was removed temporarily because he probably wanted to remake it at the time (which he did eventually end up doing in [`V3`](/Posts/Update-Log/3-0-0) of the game). The reason also could have been because of lag or some code of it needing to be updated when BOB didn't feel like it.
 
 The design of the stage has changed a little bit over the years. Here's a list of those changes or at least the ones BOB can remember:
 
@@ -43,7 +43,7 @@ The design of the stage has changed a little bit over the years. Here's a list o
 |-|-|
 | Reserved Dock Entrance   | `1` |
 | Entrances Used           | `1` - This is set to 1 due to it causing technical issues if it is bigger but the stage does take up more than 1 dock entrance. |
-| Dock Entrance Types Used | {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)} |
+| Dock Entrance Types Used | {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)} |
 | Side Placed On           | `Middle Side 1` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Game/Weird-Hills-Dock.md
+++ b/Wiki/Dock-Pages/Game/Weird-Hills-Dock.md
@@ -16,7 +16,7 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Main Side 2`"
 ---
@@ -27,7 +27,7 @@ BOB can never be sure why exactly he made this dock as he doesn't remember why a
 |-|-|
 | Reserved Dock Entrance   | *None (unset)* |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)} |
+| Dock Entrance Types Used | {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)} |
 | Side Placed On           | `Main Side 2` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Game/Wheel-of-Oddities-Dock.md
+++ b/Wiki/Dock-Pages/Game/Wheel-of-Oddities-Dock.md
@@ -16,7 +16,7 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open - New Dock`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open-New-Dock)} but on November 3rd at noon it will automatically be changed to {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open - New Dock`](/Wiki/Dock-Entrance-Types/Open-New-Dock)} but on November 3rd at noon it will automatically be changed to {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Main Side 2`"
 ---
@@ -33,7 +33,7 @@ Once the arrow starts to try to center itself it has 30 seconds to land on somet
 |-|-|
 | Reserved Dock Entrance   | `2` but on November 3rd at noon it will automatically be changed to *None (unset)* |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Open - New Dock`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open-New-Dock)} but on November 3rd at noon it will automatically be changed to {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)} |
+| Dock Entrance Types Used | {`1` = [`Open - New Dock`](/Wiki/Dock-Entrance-Types/Open-New-Dock)} but on November 3rd at noon it will automatically be changed to {`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)} |
 | Side Placed On           | `Main Side 2` |
 {: .psi-panel-alternative}
 
@@ -109,7 +109,7 @@ Once the arrow starts to try to center itself it has 30 seconds to land on somet
 |-|-|
 | Listed As                 | OOF |
 | Was going to be listed as |  |
-| Does                      | Explodes your character in the same exact way as the [Mine Dock](/RBAP-Wiki/Wiki/Docks/Mine-Dock). |
+| Does                      | Explodes your character in the same exact way as the [Mine Dock](/Wiki/Docks/Mine-Dock). |
 | Expires After             |  |
 | Other Info                |  |
 

--- a/Wiki/Dock-Pages/Removed/Color-Blocks-Dock.md
+++ b/Wiki/Dock-Pages/Removed/Color-Blocks-Dock.md
@@ -16,7 +16,7 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Main Side 1`"
 ---
@@ -27,7 +27,7 @@ This is an old dock that was used to test out Roblox's [`ClickDetector`](https:/
 |-|-|
 | Reserved Dock Entrance   |  |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types#open)} |
+| Dock Entrance Types Used | {`1` = [`Open`](/Wiki/Dock-Entrance-Types#open)} |
 | Side Placed On           | `Main Side 1` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Removed/Color-Mixer-Dock.md
+++ b/Wiki/Dock-Pages/Removed/Color-Mixer-Dock.md
@@ -16,7 +16,7 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Main Side 1`"
 ---
@@ -27,7 +27,7 @@ In this dock you were able to select a color and it would show up on the machine
 |-|-|
 | Reserved Dock Entrance   |  |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types#open)} |
+| Dock Entrance Types Used | {`1` = [`Open`](/Wiki/Dock-Entrance-Types#open)} |
 | Side Placed On           | `Main Side 1` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Removed/Events-Dock.md
+++ b/Wiki/Dock-Pages/Removed/Events-Dock.md
@@ -16,18 +16,18 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Open)}"
+          value: "{`1` = [`Open`](/Wiki/Dock-Entrance-Types/Open)}"
         - key: "Side Placed On"
           value: "`Main Side 2`"
 ---
 
-This dock was used to display recent events from many different places. When there was an event the dock entrance would be open and the dock would have a specially-designed set on it for the event. After a little while BOB tended to not use it as much then as a result it later became pretty irrelevant so it got removed. Like the [Color Mixer Dock](/RBAP-Wiki/Wiki/Docks/Color-Mixer-Dock) it is very unlikely that this will ever be added back.
+This dock was used to display recent events from many different places. When there was an event the dock entrance would be open and the dock would have a specially-designed set on it for the event. After a little while BOB tended to not use it as much then as a result it later became pretty irrelevant so it got removed. Like the [Color Mixer Dock](/Wiki/Docks/Color-Mixer-Dock) it is very unlikely that this will ever be added back.
 
 | Value Name               | Value |
 |-|-|
 | Reserved Dock Entrance   |  |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Open`](/RBAP-Wiki/Wiki/Dock-Entrance-Types#open)} |
+| Dock Entrance Types Used | {`1` = [`Open`](/Wiki/Dock-Entrance-Types#open)} |
 | Side Placed On           | `Main Side 2` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Removed/Server-And-Game-Info-Dock.md
+++ b/Wiki/Dock-Pages/Removed/Server-And-Game-Info-Dock.md
@@ -18,18 +18,18 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Server Dock`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Server-Dock)}"
+          value: "{`1` = [`Server Dock`](/Wiki/Dock-Entrance-Types/Server-Dock)}"
         - key: "Side Placed On"
           value: "`Main Side 1`"
 ---
 
-This dock shows all sorts of information about the server and the game. It was originally made before [`V3`](/RBAP-Wiki/Posts/Update-Log/3-0-0) of the game but for reasons unknown was not added until [`V3`](/RBAP-Wiki/Posts/Update-Log/3-0-0). The system that runs the dock was completely recoded in [`V4`](/RBAP-Wiki/Posts/Update-Log/4-0-0). This dock has always been considered a system dock.
+This dock shows all sorts of information about the server and the game. It was originally made before [`V3`](/Posts/Update-Log/3-0-0) of the game but for reasons unknown was not added until [`V3`](/Posts/Update-Log/3-0-0). The system that runs the dock was completely recoded in [`V4`](/Posts/Update-Log/4-0-0). This dock has always been considered a system dock.
 
 | Value Name               | Value |
 |-|-|
 | Reserved Dock Entrance   |  |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Server Dock`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Server-Dock)} |
+| Dock Entrance Types Used | {`1` = [`Server Dock`](/Wiki/Dock-Entrance-Types/Server-Dock)} |
 | Side Placed On           | `Main Side 1` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Dock-Pages/Removed/Update-Logs-Dock.md
+++ b/Wiki/Dock-Pages/Removed/Update-Logs-Dock.md
@@ -18,7 +18,7 @@ page_subject_info:
         - key: "Entrances Used"
           value: "`1`"
         - key: "Dock Entrance Types Used"
-          value: "{`1` = [`Update Logs Dock`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Update-Logs-Dock)}"
+          value: "{`1` = [`Update Logs Dock`](/Wiki/Dock-Entrance-Types/Update-Logs-Dock)}"
         - key: "Side Placed On"
           value: "`Main Side 1`"
 ---
@@ -29,7 +29,7 @@ This dock houses the game's update logs. Update logs listed on the dock are retr
 |-|-|
 | Reserved Dock Entrance   |  |
 | Entrances Used           | `1` |
-| Dock Entrance Types Used | {`1` = [`Update Logs Dock`](/RBAP-Wiki/Wiki/Dock-Entrance-Types/Update-Logs-Dock)} |
+| Dock Entrance Types Used | {`1` = [`Update Logs Dock`](/Wiki/Dock-Entrance-Types/Update-Logs-Dock)} |
 | Side Placed On           | `Main Side 2` |
 {: .psi-panel-alternative}
 

--- a/Wiki/Docks.md
+++ b/Wiki/Docks.md
@@ -7,7 +7,7 @@ listed_page_category: "docks_category_page"
 
 What is a dock? Docks are where BOB showcases his building skills and sometimes his scripting skills.
 
-In the current version of the Random Buildings And Parts most docks are automatically placed by a system that was introduced in [`V3`](/RBAP-Wiki/Posts/Update-Log/3-0-0) of the game. Most docks don't have any set positions on where they will be placed so for docks like that the system will place them in alphabetical order. So that means most docks are placed completely randomly and can be moved anytime.
+In the current version of the Random Buildings And Parts most docks are automatically placed by a system that was introduced in [`V3`](/Posts/Update-Log/3-0-0) of the game. Most docks don't have any set positions on where they will be placed so for docks like that the system will place them in alphabetical order. So that means most docks are placed completely randomly and can be moved anytime.
 
 ### Here's a list of each of the dock data values:
 
@@ -15,7 +15,7 @@ In the current version of the Random Buildings And Parts most docks are automati
 |-|-|-|
 | Reserved Dock Entrance | Number or none                                      | This is the predetermined id of the dock entrance where the dock will be placed at. If this value is blank the system will pick the next available dock entrance on the side specified by the `Side Placed On` value. |
 | Entrances Used         | Number                                              | This specifies the amount of dock entrances that need to be reserved to a dock because of its size. |
-| Dock Entrance Types Used        | Table of [`Dock Entrance Types`](/RBAP-Wiki/Wiki/Dock-Entrance-Types) | For each dock entrance that is taken up by a dock this value specifies what the dock entrance type of each of those dock entrances is. |
+| Dock Entrance Types Used        | Table of [`Dock Entrance Types`](/Wiki/Dock-Entrance-Types) | For each dock entrance that is taken up by a dock this value specifies what the dock entrance type of each of those dock entrances is. |
 | Side Placed On         | Side name                                           | The side of the map the dock is to be placed on. |
 
 ## Here's the list of categories of docks:

--- a/Wiki/Game-Music.md
+++ b/Wiki/Game-Music.md
@@ -6,11 +6,11 @@ color_coded_table_boolean_enabled: true
 
 Random Buildings And Parts has a wide variety of music and this page is here to list them all. Now there's a few things you should know: The game has multiple music zones which each have their own list of music that can be played while inside of them. Due to the fact that some songs will appear in more than one music zone the list is going to be listed as one big list instead of separate lists for each zone. Another thing you should know is there are some songs that will only appear at certain times and those will be listed separately in their corresponding category. Also all music in game is from Roblox's deal with APM Music.
 
-All songs that were added in [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) were found from APM Music's website instead of how they were before, which was looking for them exclusively on Roblox. Also all or most songs added in that update were found with `Club \ Electronica`, `Electronic Instruments`, and `Instrumental Only` in the search. The only known exception to the previous statement is the Christmas music as that was all found from the same album which was found when a song from that album was in the search results.
+All songs that were added in [`V5`](/Posts/Update-Log/5-0-0) were found from APM Music's website instead of how they were before, which was looking for them exclusively on Roblox. Also all or most songs added in that update were found with `Club \ Electronica`, `Electronic Instruments`, and `Instrumental Only` in the search. The only known exception to the previous statement is the Christmas music as that was all found from the same album which was found when a song from that album was in the search results.
 
-# Here's the lists of music in the game as of [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0):
+# Here's the lists of music in the game as of [`V5`](/Posts/Update-Log/5-0-0):
 
-In [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) music that appears in certain time frames uses the game's time zone to determine what time it is. (Also the lists are not in any particular order.)
+In [`V5`](/Posts/Update-Log/5-0-0) music that appears in certain time frames uses the game's time zone to determine what time it is. (Also the lists are not in any particular order.)
 
 ### Notes key:
 
@@ -43,48 +43,48 @@ The indicators for each note are listed after the name of a song.
 | `Uptown`									| [Roblox](https://www.roblox.com/library/1845554017) + [APM](https://www.apmmusic.com/albums/SON_AFRO_0135/SON_AFRO_0135_01001)			| ❌ | ✔️ | ❌ | ❌ | 											|
 | `Winners Ahead (a)`						| [Roblox](https://www.roblox.com/library/1848366549) + [APM](https://www.apmmusic.com/albums/TIM_TIMLP_1053/TIM_TIMLP_1053_00101)			| ❌ | ❌ | ✔️ | ❌ | 											|
 | `Wonderful Day`							| [Roblox](https://www.roblox.com/library/1843397729) + [APM](https://www.apmmusic.com/albums/MYMA_JUST_0136/MYMA_JUST_0136_03601)			| ❌ | ✔️ | ❌ | ❌ | 											|
-| `Fight Together`							| [Roblox](https://www.roblox.com/library/1843324336) + [APM](https://www.apmmusic.com/albums/MYMA_JUST_0097/MYMA_JUST_0097_01401)			| ❌ | ✔️ | ❌ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Heavy Stepper`							| [Roblox](https://www.roblox.com/library/1841675430) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0877/KPM_KPM_0877_01501)				| ❌ | ❌ | ✔️ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Moonlight Party`							| [Roblox](https://www.roblox.com/library/1843367152) + [APM](https://www.apmmusic.com/albums/MYMA_JUST_0075/MYMA_JUST_0075_00601)			| ❌ | ✔️ | ❌ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Loving Electro House`					| [Roblox](https://www.roblox.com/library/1836160816) + [APM](https://www.apmmusic.com/albums/AXS_AXS_2438/AXS_AXS_2438_01901)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Digiboy`									| [Roblox](https://www.roblox.com/library/1841675326) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0877/KPM_KPM_0877_01101)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Cheerful Tropical House`					| [Roblox](https://www.roblox.com/library/1836105254) + [APM](https://www.apmmusic.com/albums/AXS_AXS_2406/AXS_AXS_2406_00601)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Hypnolove`								| [Roblox](https://www.roblox.com/library/1837663800) + [APM](https://www.apmmusic.com/albums/DED_DED_0104/DED_DED_0104_00801)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Sugar Sweat`								| [Roblox](https://www.roblox.com/library/1841589673) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0851/KPM_KPM_0851_00201)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Tender Tropical House`					| [Roblox](https://www.roblox.com/library/1836105293) + [APM](https://www.apmmusic.com/albums/AXS_AXS_2406/AXS_AXS_2406_00801)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Light It Up (b)`							| [Roblox](https://www.roblox.com/library/1837999739) + [APM](https://www.apmmusic.com/albums/JGM_JGM_0023/JGM_JGM_0023_06201)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Feeling You`								| [Roblox](https://www.roblox.com/library/1837693079) + [APM](https://www.apmmusic.com/albums/DED_DED_0131/DED_DED_0131_00601)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Jump Up`									| [Roblox](https://www.roblox.com/library/1839940083) + [APM](https://www.apmmusic.com/albums/KPM_JM_0049/KPM_JM_0049_01401)				| ❌ | ❌ | ✔️ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Angles`									| [Roblox](https://www.roblox.com/library/1841675486) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0877/KPM_KPM_0877_01701)				| ❌ | ❌ | ✔️ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Chasing the Sunrise`						| [Roblox](https://www.roblox.com/library/1837997983) + [APM](https://www.apmmusic.com/albums/JGM_JGM_0021/JGM_JGM_0021_00501)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Cloud 10 (a)`							| [Roblox](https://www.roblox.com/library/1840067026) + [APM](https://www.apmmusic.com/albums/KPM_JMOD_0004/KPM_JMOD_0004_00301)			| ✔️ | ❌ | ❌ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Extra Life`								| [Roblox](https://www.roblox.com/library/1836002215) + [APM](https://www.apmmusic.com/albums/AXS_AXS_2350~3/AXS_AXS_2350~3_00501)			| ❌ | ✔️ | ✔️ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Straight To Victory`						| [Roblox](https://www.roblox.com/library/1838659202) + [APM](https://www.apmmusic.com/albums/KAPT_KAPT_0066/KAPT_KAPT_0066_00101)			| ❌ | ✔️ | ✔️ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `The Wild One`							| [Roblox](https://www.roblox.com/library/1848269623) + [APM](https://www.apmmusic.com/albums/SPOTON_SPOTON_0003/SPOTON_SPOTON_0003_01301)	| ❌ | ❌ | ✔️ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Untouchable`								| [Roblox](https://www.roblox.com/library/1837681287) + [APM](https://www.apmmusic.com/albums/DED_DED_0109/DED_DED_0109_01101)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Good Morning Goodbye (b)`				| [Roblox](https://www.roblox.com/library/1840058466) + [APM](https://www.apmmusic.com/albums/KPM_JM_0164/KPM_JM_0164_04901)				| ❌ | ✔️ | ❌ | ✔️ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Limehouse Frog`							| [Roblox](https://www.roblox.com/library/1841462563) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0801/KPM_KPM_0801_01701)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
+| `Fight Together`							| [Roblox](https://www.roblox.com/library/1843324336) + [APM](https://www.apmmusic.com/albums/MYMA_JUST_0097/MYMA_JUST_0097_01401)			| ❌ | ✔️ | ❌ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Heavy Stepper`							| [Roblox](https://www.roblox.com/library/1841675430) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0877/KPM_KPM_0877_01501)				| ❌ | ❌ | ✔️ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Moonlight Party`							| [Roblox](https://www.roblox.com/library/1843367152) + [APM](https://www.apmmusic.com/albums/MYMA_JUST_0075/MYMA_JUST_0075_00601)			| ❌ | ✔️ | ❌ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Loving Electro House`					| [Roblox](https://www.roblox.com/library/1836160816) + [APM](https://www.apmmusic.com/albums/AXS_AXS_2438/AXS_AXS_2438_01901)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Digiboy`									| [Roblox](https://www.roblox.com/library/1841675326) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0877/KPM_KPM_0877_01101)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Cheerful Tropical House`					| [Roblox](https://www.roblox.com/library/1836105254) + [APM](https://www.apmmusic.com/albums/AXS_AXS_2406/AXS_AXS_2406_00601)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Hypnolove`								| [Roblox](https://www.roblox.com/library/1837663800) + [APM](https://www.apmmusic.com/albums/DED_DED_0104/DED_DED_0104_00801)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Sugar Sweat`								| [Roblox](https://www.roblox.com/library/1841589673) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0851/KPM_KPM_0851_00201)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Tender Tropical House`					| [Roblox](https://www.roblox.com/library/1836105293) + [APM](https://www.apmmusic.com/albums/AXS_AXS_2406/AXS_AXS_2406_00801)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Light It Up (b)`							| [Roblox](https://www.roblox.com/library/1837999739) + [APM](https://www.apmmusic.com/albums/JGM_JGM_0023/JGM_JGM_0023_06201)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Feeling You`								| [Roblox](https://www.roblox.com/library/1837693079) + [APM](https://www.apmmusic.com/albums/DED_DED_0131/DED_DED_0131_00601)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Jump Up`									| [Roblox](https://www.roblox.com/library/1839940083) + [APM](https://www.apmmusic.com/albums/KPM_JM_0049/KPM_JM_0049_01401)				| ❌ | ❌ | ✔️ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Angles`									| [Roblox](https://www.roblox.com/library/1841675486) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0877/KPM_KPM_0877_01701)				| ❌ | ❌ | ✔️ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Chasing the Sunrise`						| [Roblox](https://www.roblox.com/library/1837997983) + [APM](https://www.apmmusic.com/albums/JGM_JGM_0021/JGM_JGM_0021_00501)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Cloud 10 (a)`							| [Roblox](https://www.roblox.com/library/1840067026) + [APM](https://www.apmmusic.com/albums/KPM_JMOD_0004/KPM_JMOD_0004_00301)			| ✔️ | ❌ | ❌ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Extra Life`								| [Roblox](https://www.roblox.com/library/1836002215) + [APM](https://www.apmmusic.com/albums/AXS_AXS_2350~3/AXS_AXS_2350~3_00501)			| ❌ | ✔️ | ✔️ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Straight To Victory`						| [Roblox](https://www.roblox.com/library/1838659202) + [APM](https://www.apmmusic.com/albums/KAPT_KAPT_0066/KAPT_KAPT_0066_00101)			| ❌ | ✔️ | ✔️ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `The Wild One`							| [Roblox](https://www.roblox.com/library/1848269623) + [APM](https://www.apmmusic.com/albums/SPOTON_SPOTON_0003/SPOTON_SPOTON_0003_01301)	| ❌ | ❌ | ✔️ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Untouchable`								| [Roblox](https://www.roblox.com/library/1837681287) + [APM](https://www.apmmusic.com/albums/DED_DED_0109/DED_DED_0109_01101)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Good Morning Goodbye (b)`				| [Roblox](https://www.roblox.com/library/1840058466) + [APM](https://www.apmmusic.com/albums/KPM_JM_0164/KPM_JM_0164_04901)				| ❌ | ✔️ | ❌ | ✔️ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Limehouse Frog`							| [Roblox](https://www.roblox.com/library/1841462563) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0801/KPM_KPM_0801_01701)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
 
 ## Christmas (appears December 18th-26th):
 
 | Name | Links | Default Zone | Stage Zone | Game Rooms Dock Zone | Dance Floor Zone | Added In |
 |-|-|-|-|-|-|-|
-| `You Set Me Free c` [x3]					| [Roblox](https://www.roblox.com/library/1841446105) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_01101)				| ❌ | ✔️ | ✔️ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Make What You Got c` [x3]				| [Roblox](https://www.roblox.com/library/1841445653) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_00101)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Rambling Rover b` [x3]					| [Roblox](https://www.roblox.com/library/1841445791) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_00501)				| ✔️ | ❌ | ❌ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Sky Lights Up c` [x3]					| [Roblox](https://www.roblox.com/library/1841445882) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_00801)				| ❌ | ❌ | ✔️ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Better Day c` [x3]						| [Roblox](https://www.roblox.com/library/1841445990) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_00901)				| ❌ | ✔️ | ✔️ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Took My Heart c` [x3]					| [Roblox](https://www.roblox.com/library/1841445989) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_01001)				| ❌ | ✔️ | ✔️ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `In Ya Face b` [x3]						| [Roblox](https://www.roblox.com/library/1841446197) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_01301)				| ❌ | ✔️ | ✔️ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Catch Me If You Can - Instrumental` [x3]	| [Roblox](https://www.roblox.com/library/1841446225) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_01401)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Going to Bristol c` [x3]					| [Roblox](https://www.roblox.com/library/1841446286) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_01501)				| ❌ | ❌ | ✔️ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Kooky Rock Out b` [x3]					| [Roblox](https://www.roblox.com/library/1841446245) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_01601)				| ✔️ | ❌ | ❌ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
-| `Castles and Crayons b` [x3]				| [Roblox](https://www.roblox.com/library/1841446397) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_01901)				| ✔️ | ❌ | ❌ | ❌ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
+| `You Set Me Free c` [x3]					| [Roblox](https://www.roblox.com/library/1841446105) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_01101)				| ❌ | ✔️ | ✔️ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Make What You Got c` [x3]				| [Roblox](https://www.roblox.com/library/1841445653) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_00101)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Rambling Rover b` [x3]					| [Roblox](https://www.roblox.com/library/1841445791) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_00501)				| ✔️ | ❌ | ❌ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Sky Lights Up c` [x3]					| [Roblox](https://www.roblox.com/library/1841445882) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_00801)				| ❌ | ❌ | ✔️ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Better Day c` [x3]						| [Roblox](https://www.roblox.com/library/1841445990) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_00901)				| ❌ | ✔️ | ✔️ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Took My Heart c` [x3]					| [Roblox](https://www.roblox.com/library/1841445989) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_01001)				| ❌ | ✔️ | ✔️ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `In Ya Face b` [x3]						| [Roblox](https://www.roblox.com/library/1841446197) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_01301)				| ❌ | ✔️ | ✔️ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Catch Me If You Can - Instrumental` [x3]	| [Roblox](https://www.roblox.com/library/1841446225) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_01401)				| ❌ | ✔️ | ❌ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Going to Bristol c` [x3]					| [Roblox](https://www.roblox.com/library/1841446286) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_01501)				| ❌ | ❌ | ✔️ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Kooky Rock Out b` [x3]					| [Roblox](https://www.roblox.com/library/1841446245) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_01601)				| ✔️ | ❌ | ❌ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
+| `Castles and Crayons b` [x3]				| [Roblox](https://www.roblox.com/library/1841446397) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_01901)				| ✔️ | ❌ | ❌ | ❌ | [`V5`](/Posts/Update-Log/5-0-0)	|
 
 ## Christmas Day (appears December 24th-25th):
 
 | Name | Links | Default Zone | Stage Zone | Game Rooms Dock Zone | Dance Floor Zone | Added In |
 |-|-|-|-|-|-|-|
-| `Christmas Party` [x5]					| [Roblox](https://www.roblox.com/library/1841446876) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_02901)				| ✔️ | ✔️ | ❌ | ✔️ | [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)	|
+| `Christmas Party` [x5]					| [Roblox](https://www.roblox.com/library/1841446876) + [APM](https://www.apmmusic.com/albums/KPM_KPM_0803/KPM_KPM_0803_02901)				| ✔️ | ✔️ | ❌ | ✔️ | [`V5`](/Posts/Update-Log/5-0-0)	|
 
-{%- comment -%} | ` `	| [Roblox](https://www.roblox.com/library/) + [APM]()	| ❌ | ❌ | ❌ | ❌ | [`V0`](/RBAP-Wiki/Posts/Update-Log/0-0-0)	| -- FYI this is used as a template {%- endcomment -%}
+{%- comment -%} | ` `	| [Roblox](https://www.roblox.com/library/) + [APM]()	| ❌ | ❌ | ❌ | ❌ | [`V0`](/Posts/Update-Log/0-0-0)	| -- FYI this is used as a template {%- endcomment -%}

--- a/Wiki/Snow-Cubes.md
+++ b/Wiki/Snow-Cubes.md
@@ -7,14 +7,14 @@ page_subject_info:
   titles_text_color: "#FFFFFF"
   main_image:
     path: "/Assets/Images/Snow-Cubes/Main.png"
-  description: "The Snow Cube model is one of the oldest if not the oldest model (as of [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)) still used in the game to this day"
+  description: "The Snow Cube model is one of the oldest if not the oldest model (as of [`V5`](/Posts/Update-Log/5-0-0)) still used in the game to this day"
 ---
 
-You may not think about it much but this little model has some history. It is (as far as BOB knows) the oldest (as of [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)) still being used model in the game. As far as anyone knows the shape of it has not been changed in any way since it was created.
+You may not think about it much but this little model has some history. It is (as far as BOB knows) the oldest (as of [`V5`](/Posts/Update-Log/5-0-0)) still being used model in the game. As far as anyone knows the shape of it has not been changed in any way since it was created.
 
 <img class="dock-image" src="/RBAP-Wiki/Assets/Images/Snow-Cubes/Main.png" alt="">
 
-# Here's the list of all the Snow Cubes' appearances as of [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0):
+# Here's the list of all the Snow Cubes' appearances as of [`V5`](/Posts/Update-Log/5-0-0):
 
 ## The Original
 
@@ -22,22 +22,22 @@ In a RBAP dev build version from 6:18 AM on 2/19/19 the Snow Cubes made its firs
 
 <img class="dock-image" src="/RBAP-Wiki/Assets/Images/Snow-Cubes/Original.png" alt="">
 
-## [Ice Cube Tray Dock](/RBAP-Wiki/Wiki/Docks/Ice-Cube-Tray-Dock)
+## [Ice Cube Tray Dock](/Wiki/Docks/Ice-Cube-Tray-Dock)
 
-Later on the same day as the original appearance at 8:33 PM the Snow Cubes made its second appearance in the new (at the time) [Ice Cube Tray Dock](/RBAP-Wiki/Wiki/Docks/Ice-Cube-Tray-Dock) (although it was not originally called a dock). This is the oldest appearance of the Snow Cubes that is (as of [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)) still in the game to this day. The Snow Cubes that are used in the dock have remained untouched ever since the dock was added.
+Later on the same day as the original appearance at 8:33 PM the Snow Cubes made its second appearance in the new (at the time) [Ice Cube Tray Dock](/Wiki/Docks/Ice-Cube-Tray-Dock) (although it was not originally called a dock). This is the oldest appearance of the Snow Cubes that is (as of [`V5`](/Posts/Update-Log/5-0-0)) still in the game to this day. The Snow Cubes that are used in the dock have remained untouched ever since the dock was added.
 
 <img class="dock-image" src="/RBAP-Wiki/Assets/Images/Snow-Cubes/Ice-Cube-Tray.png" alt="">
 
 ## Trees?
 
-Somehow the Snow Cubes managed to find their way into being a leaf on a tree. That's right, the leaves of the trees in the middle of the map use a differently colored and sized Snow Cube model. Before [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) (which brought the [Moving Spotlight Dock](/Wiki/Docks/Moving-Spotlight-Dock)) this was the only appearance of the Snow Cubes that did not use the original design of the Snow Cubes.
+Somehow the Snow Cubes managed to find their way into being a leaf on a tree. That's right, the leaves of the trees in the middle of the map use a differently colored and sized Snow Cube model. Before [`V5`](/Posts/Update-Log/5-0-0) (which brought the [Moving Spotlight Dock](/Wiki/Docks/Moving-Spotlight-Dock)) this was the only appearance of the Snow Cubes that did not use the original design of the Snow Cubes.
 
 ## [Moving Spotlight Dock](/Wiki/Docks/Moving-Spotlight-Dock)
 
-Much like with the trees the Snow Cubes made another (differently colored and shaped) appearance this time in the [Moving Spotlight Dock](/Wiki/Docks/Moving-Spotlight-Dock) added in [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0). The colors of them were actually picked by a simple randomizer script BOB wrote (and in case you're wondering there was no maximum or minimum color value set).
+Much like with the trees the Snow Cubes made another (differently colored and shaped) appearance this time in the [Moving Spotlight Dock](/Wiki/Docks/Moving-Spotlight-Dock) added in [`V5`](/Posts/Update-Log/5-0-0). The colors of them were actually picked by a simple randomizer script BOB wrote (and in case you're wondering there was no maximum or minimum color value set).
 
 ## Snow Day
 
-Starting in [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) from December 18th to the 26th the Snow Cubes make yet another appearance in a tower inspired by the Snow Cubes original appearance. The location of the tower is very close to the entrance elevator. Once it hits that time frame the tower will appear in all existing and new servers. The reason for the Snow Cubes model being used here is because due to the spotlight's ability to track the character's movements BOB wanted some way for the character to go up in height as well.
+Starting in [`V5`](/Posts/Update-Log/5-0-0) from December 18th to the 26th the Snow Cubes make yet another appearance in a tower inspired by the Snow Cubes original appearance. The location of the tower is very close to the entrance elevator. Once it hits that time frame the tower will appear in all existing and new servers. The reason for the Snow Cubes model being used here is because due to the spotlight's ability to track the character's movements BOB wanted some way for the character to go up in height as well.
 
 <img class="dock-image" src="/RBAP-Wiki/Assets/Images/Snow-Cubes/Snow-Day.png" alt="">

--- a/Wiki/The-Controller-NPC.md
+++ b/Wiki/The-Controller-NPC.md
@@ -14,7 +14,7 @@ The Controller is an NPC in the game whose job it is to type out lines of code i
 
 <img class="dock-image" src="/RBAP-Wiki/Assets/Images/The-Controller-NPC.png" alt="">
 
-# Here's every line of code available as of [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0):
+# Here's every line of code available as of [`V5`](/Posts/Update-Log/5-0-0):
 
 Unless otherwise noted a line of code is picked at random and does not happen at certain times. The list is also in no particular order.
 

--- a/Wiki/Timed-Game-Changes.md
+++ b/Wiki/Timed-Game-Changes.md
@@ -5,17 +5,17 @@ title: Timed Changes
 
 In Random Buildings And Parts there are multiple things that happen at different times of the year, each year. This page houses the list that will list them all.
 
-# Here's the list of timed changes in the game as of [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0):
+# Here's the list of timed changes in the game as of [`V5`](/Posts/Update-Log/5-0-0):
 
-The following list is listed in order by how soon it can be witnessed starting at the beginning of the year. As of [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) each one uses the game's time zone. Each of them can happen live in existing servers unless otherwise noted.
+The following list is listed in order by how soon it can be witnessed starting at the beginning of the year. As of [`V5`](/Posts/Update-Log/5-0-0) each one uses the game's time zone. Each of them can happen live in existing servers unless otherwise noted.
 
-## An easter egg in the Game Says game on the [Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock).
+## An easter egg in the Game Says game on the [Game Rooms Dock](/Wiki/Docks/Game-Rooms-Dock).
 
-Added in [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) this has a chance appear anytime during the 24th of any month. Now there is no guarantee that you'll be able to see it as it has been tested to be quite (unintentionally) rare but be looking out for it when it says to do a command. Note that the test that was conducted on it and mentioned here was done before the chance of it appearing was set to triple the normal chance.
+Added in [`V5`](/Posts/Update-Log/5-0-0) this has a chance appear anytime during the 24th of any month. Now there is no guarantee that you'll be able to see it as it has been tested to be quite (unintentionally) rare but be looking out for it when it says to do a command. Note that the test that was conducted on it and mentioned here was done before the chance of it appearing was set to triple the normal chance.
 
-## The [Old Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Old-Game-Rooms-Dock) appears.
+## The [Old Game Rooms Dock](/Wiki/Docks/Old-Game-Rooms-Dock) appears.
 
-Added in [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) the [Old Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Old-Game-Rooms-Dock) appears on the 24th of any month. There is a 15-minute warning time frame before the dock is removed in existing servers.
+Added in [`V5`](/Posts/Update-Log/5-0-0) the [Old Game Rooms Dock](/Wiki/Docks/Old-Game-Rooms-Dock) appears on the 24th of any month. There is a 15-minute warning time frame before the dock is removed in existing servers.
 
 ## The seasonal color palette is changed to Spring.
 
@@ -31,18 +31,18 @@ The seasonal color palette changes to Fall at the beginning of September.
 
 ## Halloween decorations get placed.
 
-Added in [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) for the month of October some Halloween decorations get placed on the map.
+Added in [`V5`](/Posts/Update-Log/5-0-0) for the month of October some Halloween decorations get placed on the map.
 
 ## The seasonal color palette is changed to Winter.
 
 The seasonal color palette changes to Winter at the beginning of December.
 
-## [Christmas music](/RBAP-Wiki/Wiki/Music#christmas-appears-december-18th-26th) becomes available and the map gets covered in snow.
+## [Christmas music](/Wiki/Music#christmas-appears-december-18th-26th) becomes available and the map gets covered in snow.
 
-Added in [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) [Christmas music](/RBAP-Wiki/Wiki/Music#christmas-appears-december-18th-26th) becomes available starting December 18th and ends after the 26th.
+Added in [`V5`](/Posts/Update-Log/5-0-0) [Christmas music](/Wiki/Music#christmas-appears-december-18th-26th) becomes available starting December 18th and ends after the 26th.
 
-Also added in [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) the map gets covered in snow and a [Snow Cubes](/RBAP-Wiki/Wiki/Snow-Cubes) tower appears near the start of the map. This also starts December 18th and ends after the 26th. This was originally going to be added along with the winter season color palette change and stay active until the color palette changed again but due to performance concerns it was limited to about a week instead.
+Also added in [`V5`](/Posts/Update-Log/5-0-0) the map gets covered in snow and a [Snow Cubes](/Wiki/Snow-Cubes) tower appears near the start of the map. This also starts December 18th and ends after the 26th. This was originally going to be added along with the winter season color palette change and stay active until the color palette changed again but due to performance concerns it was limited to about a week instead.
 
-## [Christmas day music](/RBAP-Wiki/Wiki/Music#christmas-day-appears-december-24th-25th) becomes available.
+## [Christmas day music](/Wiki/Music#christmas-day-appears-december-24th-25th) becomes available.
 
-Added in [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) [Christmas day music](/RBAP-Wiki/Wiki/Music#christmas-day-appears-december-24th-25th) becomes available starting December 24th and ending after the 25th.
+Added in [`V5`](/Posts/Update-Log/5-0-0) [Christmas day music](/Wiki/Music#christmas-day-appears-december-24th-25th) becomes available starting December 24th and ending after the 25th.

--- a/Wiki/Value-Types.md
+++ b/Wiki/Value-Types.md
@@ -5,21 +5,21 @@ page_categories:
 notices:
   - type: "warning"
     title: "Unmaintained Page"
-    text: "This page is no longer being actively maintained as of RBAP's [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) update. This page will still exist for at least a little while but it will not be actively linked to."
+    text: "This page is no longer being actively maintained as of RBAP's [`V5`](/Posts/Update-Log/5-0-0) update. This page will still exist for at least a little while but it will not be actively linked to."
 ---
 
 ### Here's a list of each of (or most of) the value types used on the wiki:
 
 | Value Type |
 |-|
-| [Number](/RBAP-Wiki/Wiki/Value-Types#number) |
-| [String](/RBAP-Wiki/Wiki/Value-Types#string) |
-| [Table](/RBAP-Wiki/Wiki/Value-Types#table) |
-| [Array](/RBAP-Wiki/Wiki/Value-Types#array) |
-| [Boolean](/RBAP-Wiki/Wiki/Value-Types#boolean) |
-| [Color](/RBAP-Wiki/Wiki/Value-Types#color) |
-| [Blank](/RBAP-Wiki/Wiki/Value-Types#blank) |
-| [RBAP Version](/RBAP-Wiki/Wiki/Value-Types#rbap-version) |
+| [Number](/Wiki/Value-Types#number) |
+| [String](/Wiki/Value-Types#string) |
+| [Table](/Wiki/Value-Types#table) |
+| [Array](/Wiki/Value-Types#array) |
+| [Boolean](/Wiki/Value-Types#boolean) |
+| [Color](/Wiki/Value-Types#color) |
+| [Blank](/Wiki/Value-Types#blank) |
+| [RBAP Version](/Wiki/Value-Types#rbap-version) |
 
 ## Number
 
@@ -71,4 +71,4 @@ A value type that represents a value not being set to anything. On the wiki it i
 
 ## RBAP Version
 
-A value of this type describes a certain version of Random Buildings And Parts. Update logs for the game can be found in two places as of [`V4`](/RBAP-Wiki/Posts/Update-Log/4-0-0). Those two places are in-game on the [Update Logs Dock](/RBAP-Wiki/Wiki/Docks/Category/In-Game#update-logs-dock) and [here on the wiki](/RBAP-Wiki/Update-Logs). As should be pretty obvious this value type is exclusive to the wiki.
+A value of this type describes a certain version of Random Buildings And Parts. Update logs for the game can be found in two places as of [`V4`](/Posts/Update-Log/4-0-0). Those two places are in-game on the [Update Logs Dock](/Wiki/Docks/Category/In-Game#update-logs-dock) and [here on the wiki](/Update-Logs). As should be pretty obvious this value type is exclusive to the wiki.

--- a/Wiki/Walkway-Transportation.md
+++ b/Wiki/Walkway-Transportation.md
@@ -3,30 +3,30 @@ title: Walkway Transportation
 notices:
   - type: "warning"
     title: "Unmaintained Page"
-    text: "As of RBAP's [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) update the content featured on this page is no longer very accurate as The Traveler has gone unused since that update due to multiple reasons."
+    text: "As of RBAP's [`V5`](/Posts/Update-Log/5-0-0) update the content featured on this page is no longer very accurate as The Traveler has gone unused since that update due to multiple reasons."
 ---
 
-Random Buildings And Parts currently has 2 ways of transportation across the game's map. They are the [Player Conveyors](/RBAP-Wiki/Wiki/Map-Transportation#player-conveyors) and [The Traveler](/RBAP-Wiki/Wiki/Map-Transportation#the-traveler) and only one of them can be present in a server.
+Random Buildings And Parts currently has 2 ways of transportation across the game's map. They are the [Player Conveyors](/Wiki/Map-Transportation#player-conveyors) and [The Traveler](/Wiki/Map-Transportation#the-traveler) and only one of them can be present in a server.
 
 Currently The Traveler is the fastest way to get end to end by around 35 seconds compared to the Player Conveyors. Read one of the sentences in each of the methods of travel's section for more info on how that's calculated.
 
 ## Player Conveyors
 
-The player conveyors are by far much older than The Traveler. They have been in the game in many different forms since at least around late 2018. Their current form was introduced in [`V3`](/RBAP-Wiki/Posts/Update-Log/3-0-0) of the game and is of a futuristic looking conveyor belt featuring moving textures and is inspired by RB Battles' Season 2 hub and older versions of the game (we're talking like early fourth quarter 2018).
+The player conveyors are by far much older than The Traveler. They have been in the game in many different forms since at least around late 2018. Their current form was introduced in [`V3`](/Posts/Update-Log/3-0-0) of the game and is of a futuristic looking conveyor belt featuring moving textures and is inspired by RB Battles' Season 2 hub and older versions of the game (we're talking like early fourth quarter 2018).
 
-The speed of the texture moving inside of the conveyor belts and the speed of the conveyor belts is the exact same (pretending like Roblox doesn't add visual glitches to the texture). The speed of both of them is currently around a Roblox character's default walking speed; so if you ride and walk on it at the same time you'll be going about twice the speed you normally would if you were just walking. Fun fact: The speed of each of them remains the same no matter what the length of the conveyor belts is (or in other words the distance from end to end). When tested in [`V4`](/RBAP-Wiki/Posts/Update-Log/4-0-0) using the Player Conveyors to get end to end without manually moving (starting as soon as the character start getting moved and ending when it stops) took 1 minute and 40 seconds (not counting the time it took to get on to the opposite Player Conveyor).
+The speed of the texture moving inside of the conveyor belts and the speed of the conveyor belts is the exact same (pretending like Roblox doesn't add visual glitches to the texture). The speed of both of them is currently around a Roblox character's default walking speed; so if you ride and walk on it at the same time you'll be going about twice the speed you normally would if you were just walking. Fun fact: The speed of each of them remains the same no matter what the length of the conveyor belts is (or in other words the distance from end to end). When tested in [`V4`](/Posts/Update-Log/4-0-0) using the Player Conveyors to get end to end without manually moving (starting as soon as the character start getting moved and ending when it stops) took 1 minute and 40 seconds (not counting the time it took to get on to the opposite Player Conveyor).
 
-![](/RBAP-Wiki/Assets/Images/Walkway-Transportation/Player%20Conveyors.png)
+![](/Assets/Images/Walkway-Transportation/Player%20Conveyors.png)
 
 ## The Traveler
 
-The Traveler is a special replacement of the Player Conveyors. It takes up the same amount of room as the Player Conveyors (if you don't include the guard rails). When it stops at one of its stopping points the gate (aka the guard rails nearby) are/is lowered so players can walk onto and off of it. When tested in [`V4`](/RBAP-Wiki/Posts/Update-Log/4-0-0) using The Traveler to get end to end (starting at the end of the gate's closing animation and ending at the start of the same gate's opening animation) took 1 minute and 5 seconds.
+The Traveler is a special replacement of the Player Conveyors. It takes up the same amount of room as the Player Conveyors (if you don't include the guard rails). When it stops at one of its stopping points the gate (aka the guard rails nearby) are/is lowered so players can walk onto and off of it. When tested in [`V4`](/Posts/Update-Log/4-0-0) using The Traveler to get end to end (starting at the end of the gate's closing animation and ending at the start of the same gate's opening animation) took 1 minute and 5 seconds.
 
-It was introduced in [`V4`](/RBAP-Wiki/Posts/Update-Log/4-0-0) of the game and is only available in select servers and in those select servers it replaces the Player Conveyors. It is somewhat inspired by the entrance elevator and was made completely for the fun of making it.
+It was introduced in [`V4`](/Posts/Update-Log/4-0-0) of the game and is only available in select servers and in those select servers it replaces the Player Conveyors. It is somewhat inspired by the entrance elevator and was made completely for the fun of making it.
 
 There are no plans to replace the Player Conveyors with The Traveler due to it being affected by physics thus making it very easy to break it if you do something like stand in between the barriers when they get enabled (which will most likely result in it being thrown off its track which (unless you're BOB) is something that can break it for the rest of the session). Also the fact that it only stops at the start and end of the map doesn't help much either.
 
-![](/RBAP-Wiki/Assets/Images/Walkway-Transportation/The%20Traveler.png)
+![](/Assets/Images/Walkway-Transportation/The%20Traveler.png)
 
 ### Here's its schedule:
 

--- a/_config.yml
+++ b/_config.yml
@@ -77,7 +77,7 @@ defaults:
         - name: "v5_game_info_dock_merged"
           type: "merge"
           title: "Dock Merged"
-          text: "This dock was merged into the [Game Info Dock](/RBAP-Wiki/Wiki/Docks/Game-Info-Dock) in [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0)."
+          text: "This dock was merged into the [Game Info Dock](/Wiki/Docks/Game-Info-Dock) in [`V5`](/Posts/Update-Log/5-0-0)."
         - name: "system_dock_entrance_type"
           type: "info"
           title: "System Dock Entrance Type"
@@ -238,7 +238,7 @@ defaults:
           text: "Due to how old the update described in this update log is this update log is not being actively maintained. This shouldn’t affect the usability of the page but stuff like spelling mistakes and wording is unlikely to be fixed or changed."
         - type: "warning"
           title: "Old Update Log System Extracted"
-          text: "This update log was originally made for the long gone in-game update log system from around late 2018. Due to it being from the old system it is unlikely that it will ever be given a version number due to the fact that the old system predates the current version numbers system. It is also unlikely that it will ever have a listed exact publish time. More info on this is available in the [notes about the update log system](/RBAP-Wiki/Posts/Update-Log-Notes)."
+          text: "This update log was originally made for the long gone in-game update log system from around late 2018. Due to it being from the old system it is unlikely that it will ever be given a version number due to the fact that the old system predates the current version numbers system. It is also unlikely that it will ever have a listed exact publish time. More info on this is available in the [notes about the update log system](/Posts/Update-Log-Notes)."
       categories:
         - Old Update Logs
         - Old Update Log System Extracted

--- a/_posts/2021-04-15-Update-Log-Notes.md
+++ b/_posts/2021-04-15-Update-Log-Notes.md
@@ -22,7 +22,7 @@ sidebar:
 * * * Many of the old update logs have unnecessary hype like for example some of them may say "`ALL-NEW`". BOB has stopped using this style of update log for quite some time now.
 * * * * Also there are more differences between the styles of update logs in between the old update logs and the new update logs. Overall the newer ones are of higher quality than the older ones.
 * * * Many of the changes listed in them are either changed or removed.
-* All updates after and including [`V5`](/RBAP-Wiki/Posts/Update-Log/5-0-0) use a new way of determining version numbers which is as follows (starting from the left):
+* All updates after and including [`V5`](/Posts/Update-Log/5-0-0) use a new way of determining version numbers which is as follows (starting from the left):
 * * The first number indicates a future focused update that is so impactful that It is hard to not notice a change from it (at the time of it being released). These usually contain many future focused changes.
 * * The second number Indicates update that is at least partly future focused. These usually contain future focused changes but not many of them.
 * * The third number indicates a pretty small update. These usually only contain bug fixes and/or minor improvements. They also have a chance of being made on the spot (like a quick maintenance update that wasn't planned ahead of time).

--- a/_posts/Update-Logs/2021-05-14-Update-Log-4.0.0.md
+++ b/_posts/Update-Logs/2021-05-14-Update-Log-4.0.0.md
@@ -19,14 +19,14 @@ tags:
 {: .internal-use-only}
 
 * Added a new in-game update logs system.
-* The revamped [Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock) is now back and is now enabled!
+* The revamped [Game Rooms Dock](/Wiki/Docks/Game-Rooms-Dock) is now back and is now enabled!
 * * It features following games currently:
 * * * Four Corners (which has been ported over from the old dock).
 * * * Four Corners: Reversed (which has been ported over from the old dock).
 * * * Game Says (which is a replacement for the Find The Color game from the old dock).
 * The rainbow effect has been added back.
 * The player name tag system got a well-deserved revamp.
-* The old [Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock) will not appear in newer servers in a little over a week from the time of writing.
+* The old [Game Rooms Dock](/Wiki/Docks/Game-Rooms-Dock) will not appear in newer servers in a little over a week from the time of writing.
 * A few (pretty noticeable) bugs like for example your camera not being able to look through certain objects have been fixed.
 
 {EndUpdateSummariesList}
@@ -46,35 +46,35 @@ tags:
 * * Hmm... I wonder if this update added some stuff that takes advantage of the now natively supported ability to have different versions of docks replace their counterpart? I guess we'll never know! <s class="spoiler">:)</s>
 * The text around the play button in the intro of the game now uses white text instead of black text.
 * * When that part of the intro is small enough the background color will now be set to black and will be a little less transparent.
-* The main sign in the [Bob the Mob Dock](/RBAP-Wiki/Wiki/Docks/Bob-The-Mob-Dock) now uses white text instead of black text.
+* The main sign in the [Bob the Mob Dock](/Wiki/Docks/Bob-The-Mob-Dock) now uses white text instead of black text.
 * Night has been removed so the game is now day only and street lights are set to on.
-* The [Update Logs Dock](/RBAP-Wiki/Wiki/Docks/Update-Logs-Dock) has been added! This is the V1 of the new system that replaces the old dev forum post.
+* The [Update Logs Dock](/Wiki/Docks/Update-Logs-Dock) has been added! This is the V1 of the new system that replaces the old dev forum post.
 * Completely threw out the old game loading system and replaced it with a new one. This change should be unnoticeable to the player.
 * * Due to the old system being a host of the rainbow party system the rainbow party system has been completely wiped out. The only thing that remains still in the backend of the game is it's dock. RIP.
-* The backend of the [Server And Game Info Dock](/RBAP-Wiki/Wiki/Docks/Server-And-Game-Info-Dock) (or server system dock for short) has been completely recoded from scratch. Due to this some statistics have been removed.
+* The backend of the [Server And Game Info Dock](/Wiki/Docks/Server-And-Game-Info-Dock) (or server system dock for short) has been completely recoded from scratch. Due to this some statistics have been removed.
 * Completely recoded the system that decides whether your camera can look through an object or not. This included fixes to objects that should have been able to be looked through.
 * Completely recoded the player name tags system.
-* * The new system has the natively supported ability of live updating titles. This will be used in an upcoming update ([`V4.1`](/RBAP-Wiki/Posts/Update-Log/4-1-0))!
+* * The new system has the natively supported ability of live updating titles. This will be used in an upcoming update ([`V4.1`](/Posts/Update-Log/4-1-0))!
 * * Titles now have priorities. So if a player has two titles on the same line available to them the one with the highest priority will be shown.
 * * The system has the ability to have a title apply to a wider range of players than the original system was capable of.
 * * Upgradability of this new system is much better than the old system.
 * * Kinda accidentally added the way for there to be natively supported name tags on NPCs. It isn't officially supported but there is some level of support for it (or at least future-proofs for it) if I ever want to use it.
-* The revamped [Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock) has been added back after being quietly removed in V3.1 due to my unwillingness to finally finish it. Here's a list of everything different from when it was added in V3 (and pretending like it was enabled when it was added):
+* The revamped [Game Rooms Dock](/Wiki/Docks/Game-Rooms-Dock) has been added back after being quietly removed in V3.1 due to my unwillingness to finally finish it. Here's a list of everything different from when it was added in V3 (and pretending like it was enabled when it was added):
 * * Instead of porting over the "Find The Right Color" game (like I had originally planned) a replacement for that game has been added called "Game Says". This was what was preventing the dock from being enabled.
 * * The system that handles the teleporting of your character when you fall down into the black abyss (or whatever it's called) has been improved. To be more specific it will no longer block new requests each time a player is being processed by it.
 * * * Oh and also it now handles each game room's black abyss instead of just one of them. Oops!
 * * The systems that run the dock now actually use the barriers on the dock (which wasn't the case due to an oversight done by me). Oops (again)!
-* The [Old Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Old-Game-Rooms-Dock) now has a date that it will not appear in new servers after. RIP old [Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock) 2018-2021.
+* The [Old Game Rooms Dock](/Wiki/Docks/Old-Game-Rooms-Dock) now has a date that it will not appear in new servers after. RIP old [Game Rooms Dock](/Wiki/Docks/Game-Rooms-Dock) 2018-2021.
 * * After on the end (aka midnight) of Sunday, May 23 (PDT) the dock will not appear in newer servers and in existing servers the gate on the dock's dock entrance will be raised. Also the light on the dock entrance in existing servers will turn yellow 5 minutes beforehand.
 * * I have some ideas on how I can still keep it around in the game for people who might like it but for the most part the dock won't appear in the game after the set date.
 * The rainbow effect has been added back to the game! However the rotation of the bloxy awards remake statue will not be returning.
 * The statue on the remade bloxy statue dock no longer uses any union objects which fixes collisions which has given me the ability to get rid of the barrier protecting the statue. In summary barrier be gone.
 * The rainbow dance floor has been readded to the game after being removed along with rainbow parties.
-* Both the [Rainbow Dance Floor Dock](/RBAP-Wiki/Wiki/Docks/Rainbow-Dance-Floor-Dock) and the [Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock) don't (for now at least) have their own music. This is due to technical reasons like how music zones aren't bound to any dock.
+* Both the [Rainbow Dance Floor Dock](/Wiki/Docks/Rainbow-Dance-Floor-Dock) and the [Game Rooms Dock](/Wiki/Docks/Game-Rooms-Dock) don't (for now at least) have their own music. This is due to technical reasons like how music zones aren't bound to any dock.
 * The system behind the animation of the camera during the intro now supports animations that are not bound to any dock.
 * * 3 new camera animations have been added as a result of that.
-* The camera during the intro now pays a visit to the [Stage](/RBAP-Wiki/Wiki/Docks/Stage-Dock).
-* The system behind the [No Standing Joke Dock](/RBAP-Wiki/Wiki/Docks/No-Standing-Joke-Dock) has been rewritten entirely. It is much better at detecting characters compared to the old system.
+* The camera during the intro now pays a visit to the [Stage](/Wiki/Docks/Stage-Dock).
+* The system behind the [No Standing Joke Dock](/Wiki/Docks/No-Standing-Joke-Dock) has been rewritten entirely. It is much better at detecting characters compared to the old system.
 * The play button in the intro can no longer be clicked through the loading screen. Sorry but the loading screen is there for a reason.
 * Fixed a bug that made it so you could walk right through the walls of the original window showcase. Quite literally no idea why this happened or when it started but it's fixed now.
 * * Thanks to copy and pasting the bug also affected the newer window showcase.

--- a/_posts/Update-Logs/2021-06-24-Update-Log-4.1.0.md
+++ b/_posts/Update-Logs/2021-06-24-Update-Log-4.1.0.md
@@ -20,7 +20,7 @@ tags:
 * A new settings panel has been added! You can find the button for it at the bottom right of your screen.
 * * There is now the ability to change what titles you have equipped!
 * Donation amounts now give special titles and donation amount #6 is back.
-* The text on the [Update Logs Dock](/RBAP-Wiki/Wiki/Docks/Update-Logs-Dock) should be nicer to look at and more readable now.
+* The text on the [Update Logs Dock](/Wiki/Docks/Update-Logs-Dock) should be nicer to look at and more readable now.
 
 {EndUpdateSummariesList}
 {: .internal-use-only}
@@ -43,7 +43,7 @@ tags:
 * * The panel is automatically scaled depending on the screen size. It currently has a minimum of 60% of its normal size and no maximum.
 * Some new rewards for purchasing donations have been added: They are titles! Each donation amount has its own title with the color getting brighter and the wording getting better as you purchase higher and higher donation amounts.
 * Donation amount #5 has been decreased to 250 Robux and donation amount #6 has been put back onsale (for the original price of donation amount #5 (which is 1000 Robux)).
-* Both lists of changes on the [Update Logs Dock](/RBAP-Wiki/Wiki/Docks/Update-Logs-Dock) have been changed:
+* Both lists of changes on the [Update Logs Dock](/Wiki/Docks/Update-Logs-Dock) have been changed:
 * * The overall amount of space dedicated to a change is now automatically determined instead of manually.
 * * The text is no longer scaled by Roblox meaning everything is the same size. Overall text size is lower then it used to be though.
 * * There is now a wider gap in between each change.
@@ -57,8 +57,8 @@ tags:
 * * The enter key will be pressed when the entry box is cleared.
 * The corners of the desk used by the guy that types lines of code into the fake console are now rounded.
 * The device prediction algorithm now knows if you're on Windows or not (and if you are it will mark you as using a computer).
-* Removed the is the server officially recognized statistic from the [Server And Game Info Dock](/RBAP-Wiki/Wiki/Docks/Server-And-Game-Info-Dock) due to it being pretty pointless.
-* Edited (and added fixes to) how the live updating titles system of the new name tags system that was introduced in the previous update ([`V4`](/RBAP-Wiki/Posts/Update-Log/4-0-0)) works.
+* Removed the is the server officially recognized statistic from the [Server And Game Info Dock](/Wiki/Docks/Server-And-Game-Info-Dock) due to it being pretty pointless.
+* Edited (and added fixes to) how the live updating titles system of the new name tags system that was introduced in the previous update ([`V4`](/Posts/Update-Log/4-0-0)) works.
 
 {EndUpdateChangesList}
 {: .internal-use-only}

--- a/_posts/Update-Logs/2021-06-25-Update-Log-4.1.1.md
+++ b/_posts/Update-Logs/2021-06-25-Update-Log-4.1.1.md
@@ -30,9 +30,9 @@ tags:
 {StartUpdateChangesList}
 {: .internal-use-only}
 
-* Fixed the [Update Logs Dock](/RBAP-Wiki/Wiki/Docks/Update-Logs-Dock).
-* Fixed the [Server And Game Info Dock](/RBAP-Wiki/Wiki/Docks/Server-And-Game-Info-Dock).
-* Couldn't fix the [Donations Dock](/RBAP-Wiki/Wiki/Docks/Donations-Dock). It will remain not in the game until Roblox fixes the issue as it appears to be on their end and not mine.
+* Fixed the [Update Logs Dock](/Wiki/Docks/Update-Logs-Dock).
+* Fixed the [Server And Game Info Dock](/Wiki/Docks/Server-And-Game-Info-Dock).
+* Couldn't fix the [Donations Dock](/Wiki/Docks/Donations-Dock). It will remain not in the game until Roblox fixes the issue as it appears to be on their end and not mine.
 * * In case you're wondering the issue is this: Donation amount #6 is indeed onsale but for one reason or another the Roblox engine will not let you buy it with the error saying it's offsale even though everywhere else (including Roblox's API which is used to list the prices on the dock) says that it's onsale.
 * Added some minor functionality to the dock placing system. This wasn't really intended to be added in this update so none of the functionality is actually used in this update.
 

--- a/_posts/Update-Logs/2021-10-03-Update-Log-4.1.2.md
+++ b/_posts/Update-Logs/2021-10-03-Update-Log-4.1.2.md
@@ -1,7 +1,7 @@
 ---
 permalink: /Posts/Update-Log/4-1-2
 title: "V4.1.2 Update Log"
-short_description: "This update fixes the [Donations Dock](/RBAP-Wiki/Wiki/Docks/Donation-Dock)."
+short_description: "This update fixes the [Donations Dock](/Wiki/Docks/Donation-Dock)."
 update_published_at: "2021-10-03 05:15:00 +00:00"
 post_created_at: "2021-10-03 00:00:00 +00:00"
 post_updated_at: "2021-10-03 00:00:00 +00:00"
@@ -18,7 +18,7 @@ tags:
 {StartUpdateSummariesList}
 {: .internal-use-only}
 
-* Fixed the [Donations Dock](/RBAP-Wiki/Wiki/Docks/Donation-Dock) and added it back.
+* Fixed the [Donations Dock](/Wiki/Docks/Donation-Dock) and added it back.
 
 {EndUpdateSummariesList}
 {: .internal-use-only}
@@ -29,7 +29,7 @@ tags:
 {StartUpdateChangesList}
 {: .internal-use-only}
 
-* Fixed the [Donations Dock](/RBAP-Wiki/Wiki/Docks/Donation-Dock) and added it back. This is a quick but not ideal fix on my end, Roblox's end is still broken.
+* Fixed the [Donations Dock](/Wiki/Docks/Donation-Dock) and added it back. This is a quick but not ideal fix on my end, Roblox's end is still broken.
 
 {EndUpdateChangesList}
 {: .internal-use-only}

--- a/_posts/Update-Logs/2021-10-06-Update-Log-5.0.0.md
+++ b/_posts/Update-Logs/2021-10-06-Update-Log-5.0.0.md
@@ -20,14 +20,14 @@ tags:
 {StartUpdateSummariesList}
 {: .internal-use-only}
 
-* Added two new docks! The [Wheel of Oddities Dock](/RBAP-Wiki/Wiki/Docks/Wheel-of-Oddities-Dock) and the [Moving Spotlight Dock](/RBAP-Wiki/Wiki/Docks/Moving-Spotlight-Dock) both of which are interactive.
+* Added two new docks! The [Wheel of Oddities Dock](/Wiki/Docks/Wheel-of-Oddities-Dock) and the [Moving Spotlight Dock](/Wiki/Docks/Moving-Spotlight-Dock) both of which are interactive.
 * New docks will now temporarily be placed near the entrance elevator with the signs of the dock entrances used by the dock having a new dock indicator on them.
-* Updated the [Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock):
+* Updated the [Game Rooms Dock](/Wiki/Docks/Game-Rooms-Dock):
 * * Recoded the entire system.
-* * Added the [Light Chaser](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock#light-chaser) game.
-* * Updated the [Four Corners](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock#four-corners), the [Four Corners: Reversed](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock#four-corners-reversed), and the [Game Says](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock#game-says) game.
-* Added back a thing that will now only appear on the 24th of any month: The old [Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock)!
-* Merged the [Update Logs Dock](/RBAP-Wiki/Wiki/Docks/Update-Logs-Dock) and the [Server And Game Info Dock](/RBAP-Wiki/Wiki/Docks/Server-And-Game-Info-Dock) into a new dock called the [Game Info Dock](/RBAP-Wiki/Wiki/Docks/Game-Info-Dock).
+* * Added the [Light Chaser](/Wiki/Docks/Game-Rooms-Dock#light-chaser) game.
+* * Updated the [Four Corners](/Wiki/Docks/Game-Rooms-Dock#four-corners), the [Four Corners: Reversed](/Wiki/Docks/Game-Rooms-Dock#four-corners-reversed), and the [Game Says](/Wiki/Docks/Game-Rooms-Dock#game-says) game.
+* Added back a thing that will now only appear on the 24th of any month: The old [Game Rooms Dock](/Wiki/Docks/Game-Rooms-Dock)!
+* Merged the [Update Logs Dock](/Wiki/Docks/Update-Logs-Dock) and the [Server And Game Info Dock](/Wiki/Docks/Server-And-Game-Info-Dock) into a new dock called the [Game Info Dock](/Wiki/Docks/Game-Info-Dock).
 * * Although the merging of those two docks is the major change there is also a new sign which displays the game's credits.
 * Remodeled the model used for dock entrances. It has a lot more detail than the previous one and is overall more lighter.
 * The plant beds model has been removed and replaced with a single plant bed in the center of the map where the Player Conveyors used to be.
@@ -35,9 +35,9 @@ tags:
 * Added new functionality to falling off of the map:
 * * Now when you fall off the map there are points all around the map where you could be teleported to. If one of those points is closer than a randomly selected spawn location then you will ultimately land around that point.
 * Recoded the entire music system.
-* * Since I was working on the music system I decided to add some new songs. Refer to [the new wiki page on it](/RBAP-Wiki/Wiki/Music) for more info.
-* * Added back special music to the intro **and** added back special music to the [Rainbow Dance Floor Dock](/RBAP-Wiki/Wiki/Docks/Rainbow-Dance-Floor-Dock).
-* * Also added some new on screen UI that indicates what song has started playing. Unlike the one in the [Stage](/RBAP-Wiki/Wiki/Docks/Stage-Dock) this one is temporary and only lasts for a few seconds.
+* * Since I was working on the music system I decided to add some new songs. Refer to [the new wiki page on it](/Wiki/Music) for more info.
+* * Added back special music to the intro **and** added back special music to the [Rainbow Dance Floor Dock](/Wiki/Docks/Rainbow-Dance-Floor-Dock).
+* * Also added some new on screen UI that indicates what song has started playing. Unlike the one in the [Stage](/Wiki/Docks/Stage-Dock) this one is temporary and only lasts for a few seconds.
 * The dock placing system has now been completely remade! It is also now officially called the Dock System.
 * * It includes the ability to live add and remove docks! The previous system only added docks when the game was doing initial loading.
 * Changed the most key lighting settings.
@@ -45,7 +45,7 @@ tags:
 * Changed the skybox to a custom one and added Roblox's atmosphere effect and Roblox's clouds to supplement it.
 * Added what I like to call a snow day to the game which is to say during December 18th to 26th most of the map gets covered in snow.
 * Added some Halloween decorations during the month of October.
-* There's now a more unified way to have a time zone used by most of the game. Look for the new statistic on the Server And Game Info sign on the [Game Info Dock](/RBAP-Wiki/Wiki/Docks/Game-Info-Dock) for the time zone being used.
+* There's now a more unified way to have a time zone used by most of the game. Look for the new statistic on the Server And Game Info sign on the [Game Info Dock](/Wiki/Docks/Game-Info-Dock) for the time zone being used.
 * The time of day is now set to the time of the game's time zone.
 * Added two more dock entrances to both main sides of the map.
 
@@ -58,7 +58,7 @@ tags:
 {StartUpdateChangesList}
 {: .internal-use-only}
 
-* Added two new docks! The [Wheel of Oddities Dock](/RBAP-Wiki/Wiki/Docks/Wheel-of-Oddities-Dock) and the [Moving Spotlight Dock](/RBAP-Wiki/Wiki/Docks/Moving-Spotlight-Dock) both of which are interactive.
+* Added two new docks! The [Wheel of Oddities Dock](/Wiki/Docks/Wheel-of-Oddities-Dock) and the [Moving Spotlight Dock](/Wiki/Docks/Moving-Spotlight-Dock) both of which are interactive.
 * The dock placing system has now been completely remade! It is also now officially called the Dock System.
 * * It includes the ability to live add and remove docks! The previous system only added docks when the game was doing initial loading.
 * * It is also **much** more flexible and robust than the old system.
@@ -67,42 +67,42 @@ tags:
 * * Dock entrances 1, 2, and 3 on the map's main sides 1 and 2 are now only for docks with reserved dock entrances. Meaning docks will not be automatically placed at those dock entrances.
 * New docks will now temporarily be placed near the entrance elevator with the signs of the dock entrances used by the dock having a new dock indicator on them. (*Only works with certain supported dock entrance types.)
 * * The length of how long they're placed there is not a hard set number and is set manually for each dock.
-* Updated the [Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock):
+* Updated the [Game Rooms Dock](/Wiki/Docks/Game-Rooms-Dock):
 * * Played around with the coloring of all the platforms in the game rooms.
 * * * Also changed the platform colors that are used in each game.
 * * Recoded the entire system. Unlike other system recodes (for example the new Dock System) this one was not made to add big features it is simply just to give the system a facelift backend-wise.
 * * * There shouldn't be many user-facing differences compared to the old system. In fact a lot of this system is based off the old system.
-* * Updated the [Game Says](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock#game-says) game:
+* * Updated the [Game Says](/Wiki/Docks/Game-Rooms-Dock#game-says) game:
 * * * It now has 7 rounds instead of 10.
 * * * There's an easter egg that has been added that can only be found on the 24th of any month or when Unbitterness is in the server when the Game Says game starts. (The 24th was (*unknowingly*) chosen by Unbitterness btw.)
-* * Updated the [Four Corners](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock#four-corners) and the [Four Corners: Reversed](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock#four-corners-reversed) game:
+* * Updated the [Four Corners](/Wiki/Docks/Game-Rooms-Dock#four-corners) and the [Four Corners: Reversed](/Wiki/Docks/Game-Rooms-Dock#four-corners-reversed) game:
 * * * When one of the colored platforms is being lowered the text on top of them is no longer abruptly removed.
-* * Added the [Light Chaser](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock#light-chaser) game.
+* * Added the [Light Chaser](/Wiki/Docks/Game-Rooms-Dock#light-chaser) game.
 * * Made it so you're no longer able to walk under the Game Rooms' barriers.
-* Another thing has been added that will only appear on the 24th of any month as well: The old [Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock)! (Day also (*unknowingly*) chosen by Unbitterness btw.)
+* Another thing has been added that will only appear on the 24th of any month as well: The old [Game Rooms Dock](/Wiki/Docks/Game-Rooms-Dock)! (Day also (*unknowingly*) chosen by Unbitterness btw.)
 * * Once it turns the 24th of any month the dock will be placed in all existing and new servers. At 11:45 PM the dock entrance's dock entrance type will be changed. Then at midnight the gate of the dock entrance will be raised. Finally at 15 minutes after the gate is raised the dock will be removed.
 * * * Each of these timed events has a margin of error of at most a minute (not counting the accuracy of lua API).
-* Merged the [Update Logs Dock](/RBAP-Wiki/Wiki/Docks/Update-Logs-Dock) and the [Server And Game Info Dock](/RBAP-Wiki/Wiki/Docks/Server-And-Game-Info-Dock) into a new dock called the [Game Info Dock](/RBAP-Wiki/Wiki/Docks/Game-Info-Dock).
+* Merged the [Update Logs Dock](/Wiki/Docks/Update-Logs-Dock) and the [Server And Game Info Dock](/Wiki/Docks/Server-And-Game-Info-Dock) into a new dock called the [Game Info Dock](/Wiki/Docks/Game-Info-Dock).
 * * Although the merging of those two docks is the major change there is also a new sign which displays the game's credits.
 * * [Insert lore about the sign design being redesigned due to "advances in new technologies" here lol]
 * * * (Hopefully the readability is still fine as I tried my best to keep it futuristic but also readable.)
-* * For now the [Donations Dock](/RBAP-Wiki/Wiki/Docks/Donation-Dock) will not be affected from this change do to it (at the time of writing) still being broken among other reasons.
+* * For now the [Donations Dock](/Wiki/Docks/Donation-Dock) will not be affected from this change do to it (at the time of writing) still being broken among other reasons.
 * Remodeled the model used for dock entrances. It has a lot more detail than the previous one and is overall more lighter.
 * The plant beds model has been removed and replaced with a single plant bed in the center of the map where the Player Conveyors used to be.
 * * It includes stuff like taller trees and use of Roblox's grass.
 * * As a result of this change other changes have happened:
 * * * Added 1 (but technically 2) new street light designs.
-* * * Moved the [Player Conveyors](/RBAP-Wiki/Wiki/Walkway-Transportation#player-conveyors).
+* * * Moved the [Player Conveyors](/Wiki/Walkway-Transportation#player-conveyors).
 * * * Made the middle of the map 30 studs wider.
 * * * Moved the map slightly up in order to be on par with Roblox terrain's 4x4x4 size.
 * Recoded the entire music system.
 * * Much like the game rooms dock recode this recode was done to clean up the backend of the system as it was getting **very** dated.
 * * * Fun fact: To give you an idea of how bad it was that was the *original* custom music system from *at least* a year ago that I made while having no idea what I was doing + barely any idea on how to make it.
-* * Since I was working on the music system I decided to add some new songs. Refer to [the new wiki page on it](/RBAP-Wiki/Wiki/Music) for more info.
+* * Since I was working on the music system I decided to add some new songs. Refer to [the new wiki page on it](/Wiki/Music) for more info.
 * * * Also fixed a few songs that accidentally used the promo version of them.
-* * Added back special music to the intro **and** added back special music to the [Rainbow Dance Floor Dock](/RBAP-Wiki/Wiki/Docks/Rainbow-Dance-Floor-Dock) (not using the original music sadly).
+* * Added back special music to the intro **and** added back special music to the [Rainbow Dance Floor Dock](/Wiki/Docks/Rainbow-Dance-Floor-Dock) (not using the original music sadly).
 * * Added the ability to have music available to be played only in certain time frames.
-* * Also added some new on screen UI that indicates what song has started playing. Unlike the one in the [Stage](/RBAP-Wiki/Wiki/Docks/Stage-Dock) this one is temporary and only lasts for a few seconds.
+* * Also added some new on screen UI that indicates what song has started playing. Unlike the one in the [Stage](/Wiki/Docks/Stage-Dock) this one is temporary and only lasts for a few seconds.
 * * The only feature that this new music system drops is the music muting when the Roblox client is not focused.
 * Added new functionality to falling off of the map:
 * * Now when you fall off the map there are points all around the map where you could be teleported to. If one of those points is closer than a randomly selected spawn location then you will ultimately land around that point. If the spawn location is closer than the nearest point the old functionality will be used.
@@ -116,12 +116,12 @@ tags:
 * * RIP the old skybox 2019-2021.
 * Added what I like to call a snow day to the game which is to say during December 18th to 26th most of the map gets covered in snow.
 * Added some Halloween decorations during the month of October.
-* There's now a more unified way to have a time zone used by most of the game. Look for the new statistic on the Server And Game Info sign on the [Game Info Dock](/RBAP-Wiki/Wiki/Docks/Game-Info-Dock) for the time zone being used.
+* There's now a more unified way to have a time zone used by most of the game. Look for the new statistic on the Server And Game Info sign on the [Game Info Dock](/Wiki/Docks/Game-Info-Dock) for the time zone being used.
 * * The two previously listed things that happen on the 24th use the time zone listed.
-* Added other changes to the Server And Game Info sign on the [Game Info Dock](/RBAP-Wiki/Wiki/Docks/Game-Info-Dock) as well:
+* Added other changes to the Server And Game Info sign on the [Game Info Dock](/Wiki/Docks/Game-Info-Dock) as well:
 * * Fixed the server running time statistic. It wasn't necessarily broken, it was just off by around 30 seconds usually. Now it's off by around 1 second to a really long small decimal.
 * * The private server owner user id statistic has been shortened to private server owner and now displays the username instead.
-* The [NPCs Key Dock](/RBAP-Wiki/Wiki/Docks/NPCs-Key-Dock) is now considered a system dock once again.
+* The [NPCs Key Dock](/Wiki/Docks/NPCs-Key-Dock) is now considered a system dock once again.
 * The time of day is now set to the time of the game's time zone.
 * Added some improvements to the dock entrance system:
 * * Most notable is because of the remodel dock entrance types now the ability to control some new lights that I like to call warning lights. As of this update only the 3 new dock entrance types use it.
@@ -130,24 +130,24 @@ tags:
 * * You shouldn't be able to notice this change as all the immediately obvious bugs caused by this change have been fixed but there is a chance there could be others. That is why it's being mentioned here in the first place.
 * * The sun and moon will set and rise 90 degrees off to the side due to the map rotation.
 * Added 9 new dock entrance types:
-* * [Temporarily Open](/RBAP-Wiki/Wiki/Dock-Types/Temporarily-Open)
-* * [Temporarily Open - Closing Soon](/RBAP-Wiki/Wiki/Dock-Types/Temporarily-Open-Closing-Soon)
-* * [Temporarily Open - Closed Live](/RBAP-Wiki/Wiki/Dock-Types/Temporarily-Open-Closed-Live)
-* * [Open - New Dock](/RBAP-Wiki/Wiki/Dock-Types/Open-New-Dock)
-* * [Under Maintenance - New Dock](/RBAP-Wiki/Wiki/Dock-Types/Under-Maintenance-New-Dock)
-* * [Closed - New Dock](/RBAP-Wiki/Wiki/Dock-Types/Closed-New-Dock)
-* * [Donations Dock](/RBAP-Wiki/Wiki/Dock-Types/Donations-Dock)
-* * [Game Info Dock](/RBAP-Wiki/Wiki/Dock-Types/Game-Info-Dock)
-* * [NPCs Key Dock](/RBAP-Wiki/Wiki/Dock-Types/NPCs-Key-Dock)
+* * [Temporarily Open](/Wiki/Dock-Types/Temporarily-Open)
+* * [Temporarily Open - Closing Soon](/Wiki/Dock-Types/Temporarily-Open-Closing-Soon)
+* * [Temporarily Open - Closed Live](/Wiki/Dock-Types/Temporarily-Open-Closed-Live)
+* * [Open - New Dock](/Wiki/Dock-Types/Open-New-Dock)
+* * [Under Maintenance - New Dock](/Wiki/Dock-Types/Under-Maintenance-New-Dock)
+* * [Closed - New Dock](/Wiki/Dock-Types/Closed-New-Dock)
+* * [Donations Dock](/Wiki/Dock-Types/Donations-Dock)
+* * [Game Info Dock](/Wiki/Dock-Types/Game-Info-Dock)
+* * [NPCs Key Dock](/Wiki/Dock-Types/NPCs-Key-Dock)
 * Added two more dock entrances to both main sides of the map.
 * Flipped around Spring and Summer color palettes.
 * Added some very light text to the wall behind the Music Waves effect in the stage that denotes the name of it. Didn't want to make it too intrusive, that's why it's very light but still readable.
 * Changed the color, material, and height of the area beneath the entrance elevator to match the area beneath most of the center of the map.
 * Reduced Z-fighting on the rainbow dance floor when looking at it from a distance.
-* Fixed a bug where the text and the background color of the UI on the signs on the [Old Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Old-Game-Rooms-Dock) would Z-fight.
+* Fixed a bug where the text and the background color of the UI on the signs on the [Old Game Rooms Dock](/Wiki/Docks/Old-Game-Rooms-Dock) would Z-fight.
 * * I don't normally fix bugs related to removed docks and the like. This one just happened to be on my mind while I was going to bed. Also I haven't had time to test out this bug fix so no idea if it actually fixes the bug.
 * Disabled 3 spawn locations. 1 on the top floor and 2 on the bottom floor.
-* Removed the barriers around the map due to the [Wheel of Oddities Dock](/RBAP-Wiki/Wiki/Docks/Wheel-of-Oddities-Dock).
+* Removed the barriers around the map due to the [Wheel of Oddities Dock](/Wiki/Docks/Wheel-of-Oddities-Dock).
 * Added a few minor changes to 2 systems which manage the reset button and falling off of the map respectively:
 * * Both systems now take into account whether a spawn location is actually enabled or not. Also they now make sure that it's an actual spawn location too.
 * * The system that manages players' characters that have fallen off the map now checks player character locations every second instead of every quarter second.
@@ -158,5 +158,5 @@ tags:
 # Active known issues from this update
 {: .update-log-section-title}
 
-* [Moving Spotlight Dock](/RBAP-Wiki/Wiki/Docks/Moving-Spotlight-Dock):
+* [Moving Spotlight Dock](/Wiki/Docks/Moving-Spotlight-Dock):
 * * The spotlight sometimes likes to spin around before it gets used for the first time. This issue was identified sometime in or before the day that the update got released. It has been identified as being caused by Roblox's engine. I might get around to fixing this but seeing as I didn't cause it and It isn't that deal (as it can be easily mitigated by interacting with the spotlight) it isn't my top priority.

--- a/_posts/Update-Logs/2021-10-12-Update-Log-5.1.0.md
+++ b/_posts/Update-Logs/2021-10-12-Update-Log-5.1.0.md
@@ -1,7 +1,7 @@
 ---
 permalink: /Posts/Update-Log/5-1-0
 title: "V5.1.0 Update Log"
-short_description: "This update contains some minor improvements to the game. Most of them are for the Update Logs sign on the [Game Info Dock](/RBAP-Wiki/Wiki/Docks/Game-Info-Dock)."
+short_description: "This update contains some minor improvements to the game. Most of them are for the Update Logs sign on the [Game Info Dock](/Wiki/Docks/Game-Info-Dock)."
 update_published_at: "2021-10-12 18:00:00 +00:00"
 post_created_at: "2021-10-12 00:00:00 +00:00"
 post_updated_at: "2021-11-07 00:00:00 +00:00"
@@ -18,7 +18,7 @@ tags:
 {StartUpdateSummariesList}
 {: .internal-use-only}
 
-* Improved the Update Logs sign on the [Game Info Dock](/RBAP-Wiki/Wiki/Docks/Game-Info-Dock):
+* Improved the Update Logs sign on the [Game Info Dock](/Wiki/Docks/Game-Info-Dock):
 * * There are more update logs listed now.
 * * * Press the new buttons located at the top of the sign in order to flip through each one.
 * * Now when you press `Ctrl` + `U` while looking at the update logs your character will go invisible. Once you are ready to get rid of the effect simply look away from the update logs sign.
@@ -33,7 +33,7 @@ tags:
 {StartUpdateChangesList}
 {: .internal-use-only}
 
-* Improved the Update Logs sign on the [Game Info Dock](/RBAP-Wiki/Wiki/Docks/Game-Info-Dock):
+* Improved the Update Logs sign on the [Game Info Dock](/Wiki/Docks/Game-Info-Dock):
 * * There are more update logs listed now.
 * * * Press the new buttons located at the top of the sign in order to flip through each one.
 * * * For the time being it does not live update.

--- a/_posts/Update-Logs/2021-11-07-Update-Log-5.1.1.md
+++ b/_posts/Update-Logs/2021-11-07-Update-Log-5.1.1.md
@@ -1,7 +1,7 @@
 ---
 permalink: /Posts/Update-Log/5-1-1
 title: "V5.1.1 Update Log"
-short_description: "This update fixes the update log titles on update logs sign on the [Game Info Dock](/RBAP-Wiki/Wiki/Docks/Game-Info-Dock)."
+short_description: "This update fixes the update log titles on update logs sign on the [Game Info Dock](/Wiki/Docks/Game-Info-Dock)."
 update_published_at: "2021-11-07 10:00:00 +00:00"
 post_created_at: "2021-11-07 00:00:00 +00:00"
 post_updated_at: "2021-11-07 00:00:00 +00:00"
@@ -18,7 +18,7 @@ tags:
 {StartUpdateSummariesList}
 {: .internal-use-only}
 
-* Fixed the update log titles on update logs sign on the [Game Info Dock](/RBAP-Wiki/Wiki/Docks/Game-Info-Dock).
+* Fixed the update log titles on update logs sign on the [Game Info Dock](/Wiki/Docks/Game-Info-Dock).
 
 {EndUpdateSummariesList}
 {: .internal-use-only}
@@ -29,7 +29,7 @@ tags:
 {StartUpdateChangesList}
 {: .internal-use-only}
 
-* Fixed the update log titles on update logs sign on the [Game Info Dock](/RBAP-Wiki/Wiki/Docks/Game-Info-Dock).
+* Fixed the update log titles on update logs sign on the [Game Info Dock](/Wiki/Docks/Game-Info-Dock).
 
 {EndUpdateChangesList}
 {: .internal-use-only}

--- a/_posts/Update-Logs/2021-11-21-Update-Log-5.1.2.md
+++ b/_posts/Update-Logs/2021-11-21-Update-Log-5.1.2.md
@@ -1,7 +1,7 @@
 ---
 permalink: /Posts/Update-Log/5-1-2
 title: "V5.1.2 Update Log"
-short_description: "This update fixes the [Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock)."
+short_description: "This update fixes the [Game Rooms Dock](/Wiki/Docks/Game-Rooms-Dock)."
 update_published_at: "2021-11-21 01:00:00 +00:00"
 post_created_at: "2021-11-21 00:00:00 +00:00"
 post_updated_at: "2021-11-21 00:00:00 +00:00"
@@ -19,7 +19,7 @@ tags:
 {StartUpdateSummariesList}
 {: .internal-use-only}
 
-* Fixed a rare bug from [Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock) that when encountered causes a game room to stop working.
+* Fixed a rare bug from [Game Rooms Dock](/Wiki/Docks/Game-Rooms-Dock) that when encountered causes a game room to stop working.
 
 {EndUpdateSummariesList}
 {: .internal-use-only}
@@ -30,7 +30,7 @@ tags:
 {StartUpdateChangesList}
 {: .internal-use-only}
 
-* Fixed a rare bug from [Game Rooms Dock](/RBAP-Wiki/Wiki/Docks/Game-Rooms-Dock) that when encountered causes a game room to stop working.
+* Fixed a rare bug from [Game Rooms Dock](/Wiki/Docks/Game-Rooms-Dock) that when encountered causes a game room to stop working.
 
 {EndUpdateChangesList}
 {: .internal-use-only}

--- a/_posts/Update-Logs/Unmaintained/Decent/2021-01-08-Update-Log-3.0.0.md
+++ b/_posts/Update-Logs/Unmaintained/Decent/2021-01-08-Update-Log-3.0.0.md
@@ -26,7 +26,7 @@ tags:
 * * The game now decides which season it is based on real world time - It does it based on what month it is and does not look at what day it is
 * * Most screen UI has been removed
 * * * Some of it has been moved into a dock of its own
-* * The [Stage](/RBAP-Wiki/Wiki/Docks/Stage-Dock) (which is one of the oldest parts of the game) got revamped
+* * The [Stage](/Wiki/Docks/Stage-Dock) (which is one of the oldest parts of the game) got revamped
 
 {EndUpdateSummariesList}
 {: .internal-use-only}
@@ -44,13 +44,13 @@ tags:
 * * Instead of just one point of light coming from the lights at the top of the dock entrance each light now has its own point of light.
 * * The portal dock entrance type has been removed.
 * * Added the server dock entrance type.
-* The username in the signs describing where the inspiration came from on the [Bob the Mob Dock](/RBAP-Wiki/Wiki/Docks/Bob-The-Mob-Dock) now auto updates.
+* The username in the signs describing where the inspiration came from on the [Bob the Mob Dock](/Wiki/Docks/Bob-The-Mob-Dock) now auto updates.
 * The light coming from the lighthouse now has a smoother animation (along with something that I threw in for quite literally no reason that happens every <s class="spoiler">30 minutes</s>).
 * The fire pit will no longer hurt you when stepped on.
 * * Because of that the text above the fire indicating that the fire does damage has been removed.
 * The font and design of a good majority of the text in the game has changed.
 * The key card door has been removed. - Don't currently have plans to add it back but I might in the future.
-* Every form of light in the game (not including the window [Showcase Dock](/RBAP-Wiki/Wiki/Docks/Showcase-Dock)) has been changed in some way.
+* Every form of light in the game (not including the window [Showcase Dock](/Wiki/Docks/Showcase-Dock)) has been changed in some way.
 * A lot of the old barriers were removed and replaced with more organized versions of them. - They're in pretty much the same locations as the old ones but they're a lot more organized.
 * Added a new respawn system:
 * * (I have been wanting to be able to say this for a while now:) Falling off the edge of the main map now (pretty much) seamlessly teleports you a little bit above the spawn locations at the bottom part of the entrance elevator.
@@ -97,7 +97,7 @@ Output: <s class="spoiler"><code>:b</code></s>
 * * Another noticeable change is there is now a moving texture in the conveyor belts (Fun fact: That is how it used to be a while ago (although the note right below this was not a part of it)).
 * * The speed at which the texture goes is calculated based on how long the conveyor belt is and is not a set number. (Another fun fact is because it didn't used to do that that was the reason why the moving texture was removed a while ago.)
 * * The speed of the conveyor belt is identical to the speed of the texture in it. (Note that the texture in it does weird visual glitches (which is most notable when you're riding on top the conveyor) and there's nothing I can do about it.)
-* Added the [Construction Barrier Dock](/RBAP-Wiki/Wiki/Docks/Construction-Barrier-Dock).
+* Added the [Construction Barrier Dock](/Wiki/Docks/Construction-Barrier-Dock).
 * Most of the docks have been rearranged due to a new system that has been implemented that helps me organize them better.
 * Made edits to a lot of docks in the game.
 * The old window showcase has been remade! Don't worry the old one is not going away because of it.
@@ -113,14 +113,14 @@ Output: <s class="spoiler"><code>:b</code></s>
 * * Some of it has been moved into a dock of its own.
 * Technically added rainbow parties but they were removed before making it to the main game due to lag. - RIP rainbow parties.
 * The light in the lighthouse has been shut off because the code that runs it is in need of an update and does not work in its current version.
-* The [Stage](/RBAP-Wiki/Wiki/Docks/Stage-Dock) (which is one of the oldest parts of the game) has been revamped.
+* The [Stage](/Wiki/Docks/Stage-Dock) (which is one of the oldest parts of the game) has been revamped.
 * * The old one has been completely removed and rebuilt from the ground up using the old one as a little bit of a base to go off of.
 * * The music effects visual has also been updated (apart from being moved).
 * * * The code that sets how tall each part is will now takes into account the volume of the audio being played.
 * * * Because the parts were moved the number that helps in the equation to decide how tall the parts should be has been raised (meaning the parts overall height has been lowered).
-* * There is now a now playing sign in the [Stage](/RBAP-Wiki/Wiki/Docks/Stage-Dock) which will show what song that is currently playing.
+* * There is now a now playing sign in the [Stage](/Wiki/Docks/Stage-Dock) which will show what song that is currently playing.
 * Added some more music to the default music zone.
-* Remove the a few (not really at all upbeat) songs from the [Stage](/RBAP-Wiki/Wiki/Docks/Stage-Dock)'s music zone.
+* Remove the a few (not really at all upbeat) songs from the [Stage](/Wiki/Docks/Stage-Dock)'s music zone.
 
 {EndUpdateChangesList}
 {: .internal-use-only}

--- a/_posts/Update-Logs/Unmaintained/Decent/2021-01-11-Update-Log-3.0.1.md
+++ b/_posts/Update-Logs/Unmaintained/Decent/2021-01-11-Update-Log-3.0.1.md
@@ -33,15 +33,15 @@ tags:
 * * The glitching might still happen from time to time but it will not happen as much as it did before.
 * The ground material of a few of the docks has been changed from the default gray + no detail.
 * * This change includes the following docks:
-* * * The [NPCs Key Dock](/RBAP-Wiki/Wiki/Docks/NPCs-Key-Dock)
-* * * The [Construction Barrier Dock](/RBAP-Wiki/Wiki/Docks/Construction-Barrier-Dock)
-* * * The [Donations Dock](/RBAP-Wiki/Wiki/Docks/Donations-Dock)
-* * * The [Server And Game Info Dock](/RBAP-Wiki/Wiki/Docks/Server-And-Game-Info-Dock)
-* * * The [Color Mixer Dock](/RBAP-Wiki/Wiki/Docks/Color-Mixer-Dock) (which currently isn't in the game)
-* * * The [No Standing Joke Dock](/RBAP-Wiki/Wiki/Docks/No-Standing-Joke-Dock)
-* Fixed and reenabled the light in the [Lighthouse Dock](/RBAP-Wiki/Wiki/Docks/Lighthouse-Dock).
-* Fixed the mine on the [Mine Dock](/RBAP-Wiki/Wiki/Docks/Mine-Dock) (meaning the dock is no longer marked as under maintenance).
-* The [NPCs Key Dock](/RBAP-Wiki/Wiki/Docks/NPCs-Key-Dock) has lost its system dock status and is now considered a normal dock. - This was caused by me rethinking the definition of a system dock.
+* * * The [NPCs Key Dock](/Wiki/Docks/NPCs-Key-Dock)
+* * * The [Construction Barrier Dock](/Wiki/Docks/Construction-Barrier-Dock)
+* * * The [Donations Dock](/Wiki/Docks/Donations-Dock)
+* * * The [Server And Game Info Dock](/Wiki/Docks/Server-And-Game-Info-Dock)
+* * * The [Color Mixer Dock](/Wiki/Docks/Color-Mixer-Dock) (which currently isn't in the game)
+* * * The [No Standing Joke Dock](/Wiki/Docks/No-Standing-Joke-Dock)
+* Fixed and reenabled the light in the [Lighthouse Dock](/Wiki/Docks/Lighthouse-Dock).
+* Fixed the mine on the [Mine Dock](/Wiki/Docks/Mine-Dock) (meaning the dock is no longer marked as under maintenance).
+* The [NPCs Key Dock](/Wiki/Docks/NPCs-Key-Dock) has lost its system dock status and is now considered a normal dock. - This was caused by me rethinking the definition of a system dock.
 * Shrunk the map size a little. - In case you're wondering it wasn't for any particular reason.
 * `*Cough*` Added a easter egg that happens on <s class="spoiler">April 1st</s> (UTC). `*Cough*`
 


### PR DESCRIPTION
The URL to the wiki will be moving from `bobdevstudio.github.io/RBAP-Wiki` to `rbap.bobdevstudio.org` if all goes well.